### PR TITLE
Use correct sync operator for syncDeleted

### DIFF
--- a/src/Repository/EntityRepository.php
+++ b/src/Repository/EntityRepository.php
@@ -159,7 +159,7 @@ class EntityRepository implements RepositoryInterface
         }, $ids);
 
         $payload = new SyncPayload();
-        $operator = new SyncOperator($this->entityName, SyncOperator::UPSERT_OPERATOR, $data);
+        $operator = new SyncOperator($this->entityName, SyncOperator::DELETE_OPERATOR, $data);
         $payload->set($this->entityName, $operator);
 
         return $syncService->sync($payload, [], $headers);


### PR DESCRIPTION
It seems like the operator in the syncDeleted method should be `SyncOperator::DELETE_OPERATOR`, because otherwise it doesn't delete anything, and - if I understand it correctly - that's the reason for this method. 

Thanks for checking :-) 