### PR TITLE
fix histogram and terms aggregations definition

### DIFF
--- a/src/Data/Aggregation/Aggregation.php
+++ b/src/Data/Aggregation/Aggregation.php
@@ -25,4 +25,6 @@ abstract class Aggregation implements ParseAware
     public const TYPE_COUNT = 'count';
 
     public const TYPE_AVG = 'avg';
+
+    public const TYPE_HISTOGRAM = 'histogram';
 }

--- a/src/Data/Aggregation/HistogramAggregation.php
+++ b/src/Data/Aggregation/HistogramAggregation.php
@@ -8,6 +8,14 @@ use Vin\ShopwareSdk\Data\Filter\Filter;
 
 class HistogramAggregation extends Aggregation
 {
+    public const PER_MINUTE = 'minute';
+    public const PER_HOUR = 'hour';
+    public const PER_DAY = 'day';
+    public const PER_WEEK = 'week';
+    public const PER_MONTH = 'month';
+    public const PER_QUARTER = 'quarter';
+    public const PER_YEAR = 'year';
+
     public string $name;
 
     /**
@@ -19,14 +27,14 @@ class HistogramAggregation extends Aggregation
 
     public string $field;
 
-    public ?int $interval;
+    public string $interval;
 
     public ?string $format;
 
     public function __construct(
         string $name,
         string $field,
-        ?int $interval = null,
+        string $interval,
         ?string $format = null,
         ?Aggregation $aggregation = null
     ) {
@@ -41,7 +49,7 @@ class HistogramAggregation extends Aggregation
     {
         return array_filter(
             [
-                'type' => self::TYPE_FILTER,
+                'type' => self::TYPE_HISTOGRAM,
                 'name' => $this->name,
                 'field' => $this->field,
                 'interval' => $this->interval,

--- a/src/Data/Aggregation/TermsAggregation.php
+++ b/src/Data/Aggregation/TermsAggregation.php
@@ -42,7 +42,7 @@ class TermsAggregation extends Aggregation
     {
         return array_filter(
             [
-                'type' => self::TYPE_FILTER,
+                'type' => self::TYPE_TERMS,
                 'name' => $this->name,
                 'field' => $this->field,
                 'limit' => $this->limit,

--- a/tests/CriteriaTest.php
+++ b/tests/CriteriaTest.php
@@ -52,7 +52,7 @@ class CriteriaTest extends TestCase
         $criteria->addAggregation(new MinAggregation('field-min', 'field-min'));
         $criteria->addAggregation(new MaxAggregation('field-max', 'field-max'));
         $criteria->addAggregation(new AverageAggregation('field-avg', 'field-avg'));
-        $criteria->addAggregation(new HistogramAggregation('field-histogram', 'field-histogram', 500, null));
+        $criteria->addAggregation(new HistogramAggregation('field-histogram', 'field-histogram', HistogramAggregation::PER_DAY, null));
 
         $criteria->addSorting(new FieldSorting('field-sort-1', FieldSorting::DESCENDING));
         $criteria->addSorting(new FieldSorting('field-sort-2', FieldSorting::ASCENDING));
@@ -209,7 +209,7 @@ class CriteriaTest extends TestCase
                     "field" => "value-stat"
                 ],
                 [
-                    "type" => "filter",
+                    "type" => "terms",
                     "name" => "field-term",
                     "field" => "value-term"
                 ],
@@ -229,10 +229,10 @@ class CriteriaTest extends TestCase
                     "field" => "field-avg"
                 ],
                 [
-                    "type" => "filter",
+                    "type" => "histogram",
                     "name" => "field-histogram",
                     "field" => "field-histogram",
-                    "interval" => 500
+                    "interval" => 'day'
                 ]
             ],
             "grouping" => [


### PR DESCRIPTION
Hello 

I fixed the terms and histogram aggregations definition.

TermAggregation was wrongly using TYPE_FILTER 

HistogramAggregation was wrongly using TYPE_FILTER and interval property was an integer instead of a string. I added public constants as shortcut for the interval into the class too as in the shopware DAL DateHistogramAggregation definition.
The interval type change is not backward compatible but i believe that class was not used by anyone because it was not working properly due to the wrong type.

Bests
