### PR TITLE
Update EntityRepository.php

### DIFF
--- a/src/Repository/EntityRepository.php
+++ b/src/Repository/EntityRepository.php
@@ -154,8 +154,18 @@ class EntityRepository implements RepositoryInterface
 
         $headers = ['fail-on-error' => true];
 
+        if (!\is_array($ids[array_key_first($ids)]))
+        {
+            $data = array_map(function (string $id) {
+                return ['id' => $id];
+            }, $ids);
+        } else
+        {
+            $data = $ids;
+        }
+
         $payload = new SyncPayload();
-        $operator = new SyncOperator($this->entityName, SyncOperator::DELETE_OPERATOR, $ids);
+        $operator = new SyncOperator($this->entityName, SyncOperator::DELETE_OPERATOR, $data);
         $payload->set($this->entityName, $operator);
 
         return $syncService->sync($payload, [], $headers);

--- a/src/Repository/EntityRepository.php
+++ b/src/Repository/EntityRepository.php
@@ -154,12 +154,8 @@ class EntityRepository implements RepositoryInterface
 
         $headers = ['fail-on-error' => true];
 
-        $data = array_map(function (string $id) {
-            return ['id' => $id];
-        }, $ids);
-
         $payload = new SyncPayload();
-        $operator = new SyncOperator($this->entityName, SyncOperator::DELETE_OPERATOR, $data);
+        $operator = new SyncOperator($this->entityName, SyncOperator::DELETE_OPERATOR, $ids);
         $payload->set($this->entityName, $operator);
 
         return $syncService->sync($payload, [], $headers);


### PR DESCRIPTION
Wrong ID mapping on `syncDeleted()`

Based on this documentation:

https://shopware.stoplight.io/docs/admin-api/ZG9jOjEyMzA4NTUx-bulk-payloads#deleting-relations

it is currently not possible to clear out relations because of the predefined id key mapping here:
https://github.com/vienthuong/shopware-php-sdk/blob/78874d2ed9d74d6e4365b423d0284421bb7f1fa8/src/Repository/EntityRepository.php#L157-L159


I guess this might be the correct way it is intended to work:

$repository->syncDeleted([
    [
        'productId' => $product->id,
        'optionId'  => $option->id
    ]
], $context);

So I removed the use of the $data variable, as seen in my pull request.