### PR TITLE
Remove entity hydration cache, add hydration logic via DI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to `shopware-php-sdk` will be documented in this file.
 
 Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) principles.
 
+### 1.6.0
+- [Use composition instead of Traits for entity hydration logic](https://github.com/vienthuong/shopware-php-sdk/issues/46)
+- [Removed cache for hydrated entities](https://github.com/vienthuong/shopware-php-sdk/issues/46)
+
 ### 1.5.1
 - [Add property getter for Entity](https://github.com/vienthuong/shopware-php-sdk/pull/43)
 - [Introduce new admin api gateway `Vin\ShopwareSdk\Service\MediaService` to work with media endpoint and media-service in examples](https://github.com/vienthuong/shopware-php-sdk/issues/39)

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "A PHP SDK for Shopware 6 Platform",
     "type": "library",
     "license": "MIT",
-    "version": "1.5.1",
+    "version": "1.6.0",
     "authors": [
         {
             "name": "vin",

--- a/src/Factory/HydratorFactory.php
+++ b/src/Factory/HydratorFactory.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+
+namespace Vin\ShopwareSdk\Factory;
+
+use Vin\ShopwareSdk\Hydrate\EntityHydrator;
+use Vin\ShopwareSdk\Hydrate\HydratorInterface;
+
+class HydratorFactory
+{
+    public static function create(): HydratorInterface
+    {
+        return new EntityHydrator();
+    }
+}

--- a/src/Factory/RepositoryFactory.php
+++ b/src/Factory/RepositoryFactory.php
@@ -20,7 +20,7 @@ class RepositoryFactory
             $route = sprintf('/%s', $route);
         }
 
-        return new EntityRepository($definition->getEntityName(), $definition, $route);
+        return new EntityRepository($definition->getEntityName(), $definition, $route, HydratorFactory::create());
     }
 
     public static function create(string $entity, ?string $route = null): RepositoryInterface
@@ -31,7 +31,7 @@ class RepositoryFactory
 
         $definition = self::getDefinition($entity);
 
-        return new EntityRepository($entity, $definition, $route);
+        return new EntityRepository($entity, $definition, $route, HydratorFactory::create());
     }
 
     public static function setEntityMapping(array $mapping): void

--- a/src/Hydrate/HydratorInterface.php
+++ b/src/Hydrate/HydratorInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vin\ShopwareSdk\Hydrate;
+
+use Vin\ShopwareSdk\Data\Context;
+use Vin\ShopwareSdk\Data\Entity\EntityCollection;
+use Vin\ShopwareSdk\Data\Schema\Schema;
+
+interface HydratorInterface
+{
+    public function schema(string $entity, Context $context): Schema;
+
+    public function hydrateSearchResult(array $response, Context $context): EntityCollection;
+}

--- a/src/Service/AdminSearchService.php
+++ b/src/Service/AdminSearchService.php
@@ -6,18 +6,29 @@ use GuzzleHttp\Exception\BadResponseException;
 use Vin\ShopwareSdk\Data\Context;
 use Vin\ShopwareSdk\Data\Criteria;
 use Vin\ShopwareSdk\Exception\ShopwareResponseException;
+use Vin\ShopwareSdk\Factory\HydratorFactory;
+use Vin\ShopwareSdk\Hydrate\HydratorInterface;
 use Vin\ShopwareSdk\Repository\Struct\AggregationResultCollection;
 use Vin\ShopwareSdk\Repository\Struct\EntitySearchResult;
 use Vin\ShopwareSdk\Repository\Struct\SearchResultMeta;
-use Vin\ShopwareSdk\Repository\Traits\EntityHydrator;
 use Vin\ShopwareSdk\Service\Struct\KeyValuePair;
 use Vin\ShopwareSdk\Service\Struct\KeyValuePairs;
 
 class AdminSearchService extends ApiService
 {
-    use EntityHydrator;
-
     private const ADMIN_SEARCH_ENDPOINT = '/api/_admin/search';
+
+    private HydratorInterface $hydrator;
+
+    public function __construct(
+        ?Context $context = null,
+        string $contentType = 'application/vnd.api+json',
+        ?HydratorInterface $hydrator = null
+    ) {
+        $this->hydrator = $hydrator ?: HydratorFactory::create();
+
+        parent::__construct($context, $contentType);
+    }
 
     /**
      * @param  KeyValuePairs $criteriaCollection
@@ -79,7 +90,7 @@ class AdminSearchService extends ApiService
 
                 $aggregations = new AggregationResultCollection($itemResponse['aggregations'] ?? []);
 
-                $entities = $this->hydrateSearchResult($itemResponse, $context);
+                $entities = $this->hydrator->hydrateSearchResult($itemResponse, $context);
 
 
                 $meta = new SearchResultMeta($itemResponse['total'] ?? 0, Criteria::TOTAL_COUNT_MODE_EXACT);

--- a/tests/EntityRepositoryTest.php
+++ b/tests/EntityRepositoryTest.php
@@ -23,6 +23,7 @@ use Vin\ShopwareSdk\Data\Schema\Schema;
 use Vin\ShopwareSdk\Data\Uuid\Uuid;
 use Vin\ShopwareSdk\Exception\ShopwareResponseException;
 use Vin\ShopwareSdk\Factory\RepositoryFactory;
+use Vin\ShopwareSdk\Hydrate\EntityHydrator;
 use Vin\ShopwareSdk\Repository\EntityRepository;
 use Vin\ShopwareSdk\Repository\Struct\EntitySearchResult;
 use Vin\ShopwareSdk\Repository\Struct\IdSearchResult;
@@ -105,13 +106,19 @@ class EntityRepositoryTest extends TestCase
 
         $client = Client::create(['handler' => $handlerStack]);
 
-        $mockRepository = $this->getMockBuilder(EntityRepository::class)->setConstructorArgs(['custom', new CustomDefinition('custom'), '/'])->onlyMethods(['schema'])->getMock();
+        $hydrator = $this->getMockBuilder(EntityHydrator::class)->onlyMethods(['schema'])->getMock();
+        $repository = new EntityRepository(
+            'custom',
+            new CustomDefinition('custom'),
+            '/',
+            $hydrator
+        );
 
-        $mockRepository->method('schema')->willReturn(new Schema('custom', new PropertyCollection()));
-        $mockRepository->setHttpClient($client);
+        $hydrator->method('schema')->willReturn(new Schema('custom', new PropertyCollection()));
+        $repository->setHttpClient($client);
 
         /** @var CustomEntity $result */
-        $result = $mockRepository->get($customId, new Criteria(), $this->context);
+        $result = $repository->get($customId, new Criteria(), $this->context);
 
         static::assertEquals('custom', $result->getEntityName());
         static::assertInstanceOf(CustomEntity::class, $result);


### PR DESCRIPTION
- The logic to store previous entity hydrations in some cache array was removed without replacement
- All usages of _EntityTrait_ replaced with a new class _src/Hydrate/EntityHydrator.php_. New class can be injected via DI.

Related issue: https://github.com/vienthuong/shopware-php-sdk/issues/46