### PR TITLE
restore cache hydrator to avoid circular references

### DIFF
--- a/src/Factory/HydratorFactory.php
+++ b/src/Factory/HydratorFactory.php
@@ -7,8 +7,10 @@ use Vin\ShopwareSdk\Hydrate\HydratorInterface;
 
 class HydratorFactory
 {
+    public static bool $hydratorUseCache = false;
+
     public static function create(): HydratorInterface
     {
-        return new EntityHydrator();
+        return new EntityHydrator(self::$hydratorUseCache);
     }
 }


### PR DESCRIPTION
Entity Hydratation cache has been removed previously, but it was useful to avoid circular references (segfault)
This cache has been restores, optionnaly only, no cache by default

circular references can be reneraged when asking relations as : A > B > A