### PR TITLE
fix typo: rename `scopes` to `scope`

### DIFF
--- a/src/Client/AdminAuthenticator.php
+++ b/src/Client/AdminAuthenticator.php
@@ -106,7 +106,7 @@ class AdminAuthenticator
             case $grantType instanceof PasswordGrantType:
                 $formParams['password'] = $grantType->password;
                 $formParams['username'] = $grantType->username;
-                $formParams['scopes'] = $grantType->scopes;
+                $formParams['scope'] = $grantType->scopes;
                 return $formParams;
             case $grantType instanceof RefreshTokenGrantType:
                 $formParams['refresh_token'] = $grantType->refreshToken;


### PR DESCRIPTION
According to API [docs](https://shopware.stoplight.io/docs/admin-api/b3A6MTMzMTcwNzc-fetch-an-access-token) `scope` should be sent with password grant, not `scopes`

This cost me 2 hours to figure out 😅 Because Shopware wasn't generating the access token with the scope I wanted.