### PR TITLE
Changes to allow limit / page as "not given"

### DIFF
--- a/src/Data/Criteria.php
+++ b/src/Data/Criteria.php
@@ -35,9 +35,20 @@ class Criteria implements ParseAware
      */
     public const TOTAL_COUNT_MODE_NEXT_PAGES = 2;
 
-    private int $page;
 
-    private ?int $limit;
+    /**
+     * page and limit should be mixed to allow null also
+     * this would prevent from generating pagination problems
+     * 
+     * @var mixed
+     */
+    private $page;
+
+    /**
+     * see above
+     * @var mixed
+     */
+    private $limit;
 
     /**
      * Don't use term parameters together with query parameters.
@@ -84,7 +95,13 @@ class Criteria implements ParseAware
 
     private array $includes = [];
 
-    public function __construct(int $page = 1, ?int $limit = 25)
+    /**
+     * Default should be null to not limit artificily
+     *
+     * @param $page
+     * @param $limit
+     */
+    public function __construct($page = null, $limit = null)
     {
         $this->page = $page;
         $this->limit = $limit;


### PR DESCRIPTION
The current implementation will result to a limit 25 for any child-associations. We had the problem with lineItems where the collection was returning only 25 items.

Anyway there be the problem that the API has a "default" limit of 200 max. so no idea what happens if more than 200 items are returned ?!?