### PR TITLE
add missing properties

### DIFF
--- a/src/Data/Schema/Property.php
+++ b/src/Data/Schema/Property.php
@@ -16,6 +16,12 @@ class Property extends Struct
 
     public ?string $relation;
 
+    public ?string $reference;
+
+    public ?string $mapping;
+
+    public ?string $local;
+
     public ?string $localField;
 
     public ?string $referenceField;
@@ -35,9 +41,12 @@ class Property extends Struct
         $this->type = $type;
         $this->flags = $flags;
         $this->relation = $properties['relation'] ?? null;
+        $this->local = $properties['local'] ?? null;
         $this->localField = $properties['localField'] ?? null;
+        $this->reference = $properties['reference'] ?? null;
         $this->referenceField = $properties['referenceField'] ?? null;
         $this->entity = $properties['entity'] ?? null;
+        $this->mapping = $properties['mapping'] ?? null;
         $this->properties = $properties['properties'] ?? null;
         $this->name = $name;
     }

--- a/src/Service/Struct/SyncOperator.php
+++ b/src/Service/Struct/SyncOperator.php
@@ -28,6 +28,11 @@ class SyncOperator extends Struct implements ParseAware
         $this->payload = $payload;
     }
 
+    public function getEntity(): string
+    {
+        return $this->entity;
+    }
+
     public function addPayload(array $item): void
     {
         $this->payload[] = $item;


### PR DESCRIPTION
Some necessary information of the schema is missing:
```json
{
  "product": {
    "properties": {
      "options": {
        "type": "association",
        "relation": "many_to_many",
        "local": "productId",
        "reference": "optionId",
        "mapping": "product_option",
        "entity": "property_group_option",
        "flags": {
          "read_protected": [
            [
              "Shopware\\Core\\Framework\\Api\\Context\\AdminApiSource",
              "Shopware\\Core\\Framework\\Api\\Context\\SalesChannelApiSource"
            ]
          ],
          "cascade_delete": true
        },
        "localField": "id",
        "referenceField": "id"
      }
    }
  }
}
```