### PR TITLE
add: missing product visibility constants

### DIFF
--- a/src/Data/Entity/ProductVisibility/ProductVisibilityDefinition.php
+++ b/src/Data/Entity/ProductVisibility/ProductVisibilityDefinition.php
@@ -17,6 +17,12 @@ class ProductVisibilityDefinition implements EntityDefinition
 {
     public const ENTITY_NAME = 'product_visibility';
 
+    final public const VISIBILITY_LINK = 10;
+
+    final public const VISIBILITY_SEARCH = 20;
+
+    final public const VISIBILITY_ALL = 30;
+
     public function getEntityName() : string
     {
         return self::ENTITY_NAME;


### PR DESCRIPTION
To make life easier to set valid product visibility values, I've added the 3 missing constants from the original shopware code.