### PR TITLE
Add previous to shopware response exception

### DIFF
--- a/src/Client/AdminAuthenticator.php
+++ b/src/Client/AdminAuthenticator.php
@@ -13,6 +13,7 @@ use Vin\ShopwareSdk\Client\GrantType\RefreshTokenGrantType;
 use Vin\ShopwareSdk\Data\AccessToken;
 use Vin\ShopwareSdk\Data\EndPointTrait;
 use Vin\ShopwareSdk\Exception\AuthorizationFailedException;
+use Vin\ShopwareSdk\Exception\ShopwareResponseException;
 use Vin\ShopwareSdk\Exception\ShopwareUnreachableException;
 
 class AdminAuthenticator
@@ -59,7 +60,7 @@ class AdminAuthenticator
                 'headers' => self::$headers,
                 'form_params' => $formParams
             ]);
-        } catch (BadResponseException $exception) {
+        } catch (ShopwareResponseException $exception) {
             throw new AuthorizationFailedException(
                 $exception->getResponse()->getBody()->getContents(),
                 $exception->getCode(),

--- a/src/Client/Client.php
+++ b/src/Client/Client.php
@@ -192,7 +192,7 @@ class Client implements ClientInterface
 
         if ($exception instanceof ClientException || $exception instanceof ServerException) {
             $message = $exception->getResponse()->getBody()->getContents();
-            return new ShopwareResponseException($message, $exception->getResponse()->getStatusCode());
+            return new ShopwareResponseException($message, $exception->getResponse()->getStatusCode(), $exception);
         }
 
         return $exception;


### PR DESCRIPTION
Hey @vienthuong ✌️ 

This PR contains 
* **an improvement:** adding the previous exception to the `ShopwareResponseException` when it's mapped in `Client`
* **a bugfix:** catching the `ShopwareResponseException` in `AdminAuthenticator` since a `BadResponseException` always gets mapped to it in `Client::handleException()` 