### PR TITLE
fix: missing JsonSerializable implementation

### DIFF
--- a/src/Data/Struct.php
+++ b/src/Data/Struct.php
@@ -2,7 +2,7 @@
 
 namespace Vin\ShopwareSdk\Data;
 
-class Struct
+class Struct implements \JsonSerializable
 {
     /**
      * @var Struct[]


### PR DESCRIPTION
### Fix missing JsonSerializable implementation

The class Struct defines `jsonSerialize` method but does not implement the `JsonSerializable` interface. This causes the json encoding to not work properly.