### PR TITLE
fix #103 ShopwareUnreachableException and AuthorizationFailedException now extend \Exception

### DIFF
--- a/src/Client/Client.php
+++ b/src/Client/Client.php
@@ -187,7 +187,7 @@ class Client implements ClientInterface
     private static function handleException(\Throwable $exception): \Throwable
     {
         if ($exception instanceof NetworkExceptionInterface) {
-            return new ShopwareUnreachableException();
+            return new ShopwareUnreachableException($exception);
         }
 
         if ($exception instanceof ClientException || $exception instanceof ServerException) {

--- a/src/Exception/AuthorizationFailedException.php
+++ b/src/Exception/AuthorizationFailedException.php
@@ -2,6 +2,6 @@
 
 namespace Vin\ShopwareSdk\Exception;
 
-class AuthorizationFailedException extends ShopwareResponseException
+class AuthorizationFailedException extends \Exception
 {
 }

--- a/src/Exception/ShopwareUnreachableException.php
+++ b/src/Exception/ShopwareUnreachableException.php
@@ -2,10 +2,10 @@
 
 namespace Vin\ShopwareSdk\Exception;
 
-class ShopwareUnreachableException extends ShopwareResponseException
+class ShopwareUnreachableException extends \Exception
 {
-    public function __construct()
+    public function __construct(\Throwable $previous = null)
     {
-        parent::__construct('Shop is unreachable', 500);
+        parent::__construct('Shop is unreachable', 500, $previous);
     }
 }


### PR DESCRIPTION
Fixes one of the two problem in issue #103 

I consider that the `ShopwareResponseException` should be used only in cases where we get a response from a Shopware shop. In these cases we will receive a response with a specific Json body (with keys '`status`', '`title`', '`detail`', etc.).

But these two exceptions are some (most) times used whenever we did not reach the shop, and so we don't have this Json information. For that reason, I though it makes more sense to take them out of the `ShopwareResponseException` hierarchy and both of them now extend directly from `\Exception`.

Other than that, the changes include:
- `ShopwareUnreachableException` now accepts a `$previous` exception.
- `AuthorizationFailedException` never sets a Json string as a message (in order to get to this information you can access it via `$authException->getPrevious()->getResponse()`).
- `AdminAuthenticator->fetchAccessToken()` always throws an `AuthorizationFailedException` (by wrapping the previous exception), even when the problem is that the shop is not reachable.
