### PR TITLE
fix vienthuong/shopware-php-sdk/issues/109 criteria get page allow null

### DIFF
--- a/src/Data/Criteria.php
+++ b/src/Data/Criteria.php
@@ -408,12 +408,12 @@ class Criteria implements ParseAware
         return $params;
     }
 
-    public function getPage(): int
+    public function getPage(): ?int
     {
         return $this->page;
     }
 
-    public function setPage(int $page): void
+    public function setPage(?int $page): void
     {
         $this->page = $page;
     }


### PR DESCRIPTION
Fixes the described problem in vienthuong/shopware-php-sdk/issues/109.

If a criteria is created without the page parameter, the getPage method will throw the Error:
`Uncaught TypeError: Vin\ShopwareSdk\Data\Criteria::getPage(): Return value must be of type int, null returned`