### PR TITLE
Add missing $key parameter for set() method.

### DIFF
--- a/examples/MyExampleEntity/MyCustomCollection.php
+++ b/examples/MyExampleEntity/MyCustomCollection.php
@@ -1,11 +1,14 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace examples\MyExampleEntity;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
 
 /**
  * @method void add(MyCustomEntity $entity)
- * @method void set(MyCustomEntity $entity)
+ * @method void set(string $key, MyCustomEntity $entity)
  * @method MyCustomEntity[] getIterator()
  * @method MyCustomEntity[] getElements()
  * @method MyCustomEntity|null get(string $key)
@@ -14,7 +17,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class MyCustomCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return MyCustomEntity::class;
     }

--- a/script/src/CodeGenerator.php
+++ b/script/src/CodeGenerator.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace Vin\Script;
 
@@ -105,7 +107,7 @@ class CodeGenerator
         );
 
         $foo->setName($entityName . 'Entity')
-            ->setNamespaceName($entityNamespace . "\\". $entityName)
+            ->setNamespaceName($entityNamespace . "\\" . $entityName)
             ->setDocblock($docblock)
             ->addProperties($properties);
         $foo->addUse(Entity::class);
@@ -129,7 +131,7 @@ class CodeGenerator
 
         $docblock->setTags([
             new MethodTag(null, 'void', sprintf('add(%s $%s)', $entityClass, 'entity')),
-            new MethodTag(null, 'void', sprintf('set(%s $%s)', $entityClass, 'entity')),
+            new MethodTag(null, 'void', sprintf('set(string $key, %s $%s)', $entityClass, 'entity')),
             new MethodTag('getIterator', $entityClass . '[]'),
             new MethodTag('getElements', $entityClass . '[]'),
             new MethodTag(null, $entityClass . '|null', 'get(string $key)'),
@@ -186,13 +188,14 @@ class CodeGenerator
                     $valueFlag = "'$valueFlag'";
                 } elseif (is_array($valueFlag)) {
                     if ($keyFlag === 'read_protected' || $keyFlag === 'write_protected') {
-                        $valueFlag = array_map(function ($item) { return "'$item'"; }, array_merge(...$valueFlag));
+                        $valueFlag = array_map(function ($item) {
+                            return "'$item'";
+                        }, array_merge(...$valueFlag));
                         $valueFlag = "[[" . implode(", ", $valueFlag) . "]]";
                     } else {
                         $valueFlag = serialize($valueFlag);
 
                         $valueFlag = "unserialize('$valueFlag')";
-
                     }
                 }
 
@@ -236,10 +239,11 @@ class CodeGenerator
         return '<?php declare(strict_types=1);' . PHP_EOL . $foo->generate();
     }
 
-    private static function escapeJson(array $input) {
-        $escapedData = json_encode($input, JSON_HEX_QUOT|JSON_HEX_APOS );
-//        $escapedData = str_replace('"', '\\"', $escapedData );
-//        $escapedData = str_replace("'", "\\'",  $escapedData );
+    private static function escapeJson(array $input)
+    {
+        $escapedData = json_encode($input, JSON_HEX_QUOT | JSON_HEX_APOS);
+        //        $escapedData = str_replace('"', '\\"', $escapedData );
+        //        $escapedData = str_replace("'", "\\'",  $escapedData );
         return $escapedData;
     }
 
@@ -252,10 +256,10 @@ class CodeGenerator
 
         $prefix = '?';
 
-//        $flags = $property->flags;
-//        if ($flags->has('required') && $flags->get('required')->value) {
-//            $prefix = '';
-//        }
+        //        $flags = $property->flags;
+        //        if ($flags->has('required') && $flags->get('required')->value) {
+        //            $prefix = '';
+        //        }
 
         if ($property->isStringField()) {
             return $prefix . 'string';
@@ -291,17 +295,17 @@ class CodeGenerator
             case 'bool':
             case 'float':
             case 'int': {
-                return $prefix . $property->type;
-            }
+                    return $prefix . $property->type;
+                }
             case 'boolean': {
-                return $prefix . 'bool';
-            }
+                    return $prefix . 'bool';
+                }
             case 'date': {
-                return $prefix . \DateTimeInterface::class;
-            }
+                    return $prefix . \DateTimeInterface::class;
+                }
             default: {
-                return null;
-            }
+                    return null;
+                }
         }
     }
 }

--- a/src/Data/Custom/CustomCollection.php
+++ b/src/Data/Custom/CustomCollection.php
@@ -1,11 +1,14 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Custom;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
 
 /**
  * @method void add(CustomEntity $entity)
- * @method void set(CustomEntity $entity)
+ * @method void set(string $key, CustomEntity $entity)
  * @method CustomEntity[] getIterator()
  * @method CustomEntity[] getElements()
  * @method CustomEntity|null get(string $key)
@@ -14,7 +17,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class CustomCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return CustomEntity::class;
     }

--- a/src/Data/Entity/AclRole/AclRoleCollection.php
+++ b/src/Data/Entity/AclRole/AclRoleCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\AclRole;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(AclRoleEntity $entity)
- * @method void set(AclRoleEntity $entity)
+ * @method void set(string $key, AclRoleEntity $entity)
  * @method AclRoleEntity[] getIterator()
  * @method AclRoleEntity[] getElements()
  * @method AclRoleEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class AclRoleCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return AclRoleEntity::class;
     }

--- a/src/Data/Entity/AclUserRole/AclUserRoleCollection.php
+++ b/src/Data/Entity/AclUserRole/AclUserRoleCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\AclUserRole;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(AclUserRoleEntity $entity)
- * @method void set(AclUserRoleEntity $entity)
+ * @method void set(string $key, AclUserRoleEntity $entity)
  * @method AclUserRoleEntity[] getIterator()
  * @method AclUserRoleEntity[] getElements()
  * @method AclUserRoleEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class AclUserRoleCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return AclUserRoleEntity::class;
     }

--- a/src/Data/Entity/App/AppCollection.php
+++ b/src/Data/Entity/App/AppCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\App;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(AppEntity $entity)
- * @method void set(AppEntity $entity)
+ * @method void set(string $key, AppEntity $entity)
  * @method AppEntity[] getIterator()
  * @method AppEntity[] getElements()
  * @method AppEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class AppCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return AppEntity::class;
     }

--- a/src/Data/Entity/AppActionButton/AppActionButtonCollection.php
+++ b/src/Data/Entity/AppActionButton/AppActionButtonCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\AppActionButton;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(AppActionButtonEntity $entity)
- * @method void set(AppActionButtonEntity $entity)
+ * @method void set(string $key, AppActionButtonEntity $entity)
  * @method AppActionButtonEntity[] getIterator()
  * @method AppActionButtonEntity[] getElements()
  * @method AppActionButtonEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class AppActionButtonCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return AppActionButtonEntity::class;
     }

--- a/src/Data/Entity/AppActionButtonTranslation/AppActionButtonTranslationCollection.php
+++ b/src/Data/Entity/AppActionButtonTranslation/AppActionButtonTranslationCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\AppActionButtonTranslation;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(AppActionButtonTranslationEntity $entity)
- * @method void set(AppActionButtonTranslationEntity $entity)
+ * @method void set(string $key, AppActionButtonTranslationEntity $entity)
  * @method AppActionButtonTranslationEntity[] getIterator()
  * @method AppActionButtonTranslationEntity[] getElements()
  * @method AppActionButtonTranslationEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class AppActionButtonTranslationCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return AppActionButtonTranslationEntity::class;
     }

--- a/src/Data/Entity/AppAdministrationSnippet/AppAdministrationSnippetCollection.php
+++ b/src/Data/Entity/AppAdministrationSnippet/AppAdministrationSnippetCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\AppAdministrationSnippet;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(AppAdministrationSnippetEntity $entity)
- * @method void set(AppAdministrationSnippetEntity $entity)
+ * @method void set(string $key, AppAdministrationSnippetEntity $entity)
  * @method AppAdministrationSnippetEntity[] getIterator()
  * @method AppAdministrationSnippetEntity[] getElements()
  * @method AppAdministrationSnippetEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class AppAdministrationSnippetCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return AppAdministrationSnippetEntity::class;
     }

--- a/src/Data/Entity/AppCmsBlock/AppCmsBlockCollection.php
+++ b/src/Data/Entity/AppCmsBlock/AppCmsBlockCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\AppCmsBlock;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(AppCmsBlockEntity $entity)
- * @method void set(AppCmsBlockEntity $entity)
+ * @method void set(string $key, AppCmsBlockEntity $entity)
  * @method AppCmsBlockEntity[] getIterator()
  * @method AppCmsBlockEntity[] getElements()
  * @method AppCmsBlockEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class AppCmsBlockCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return AppCmsBlockEntity::class;
     }

--- a/src/Data/Entity/AppCmsBlockTranslation/AppCmsBlockTranslationCollection.php
+++ b/src/Data/Entity/AppCmsBlockTranslation/AppCmsBlockTranslationCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\AppCmsBlockTranslation;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(AppCmsBlockTranslationEntity $entity)
- * @method void set(AppCmsBlockTranslationEntity $entity)
+ * @method void set(string $key, AppCmsBlockTranslationEntity $entity)
  * @method AppCmsBlockTranslationEntity[] getIterator()
  * @method AppCmsBlockTranslationEntity[] getElements()
  * @method AppCmsBlockTranslationEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class AppCmsBlockTranslationCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return AppCmsBlockTranslationEntity::class;
     }

--- a/src/Data/Entity/AppFlowAction/AppFlowActionCollection.php
+++ b/src/Data/Entity/AppFlowAction/AppFlowActionCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\AppFlowAction;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(AppFlowActionEntity $entity)
- * @method void set(AppFlowActionEntity $entity)
+ * @method void set(string $key, AppFlowActionEntity $entity)
  * @method AppFlowActionEntity[] getIterator()
  * @method AppFlowActionEntity[] getElements()
  * @method AppFlowActionEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class AppFlowActionCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return AppFlowActionEntity::class;
     }

--- a/src/Data/Entity/AppFlowActionTranslation/AppFlowActionTranslationCollection.php
+++ b/src/Data/Entity/AppFlowActionTranslation/AppFlowActionTranslationCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\AppFlowActionTranslation;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(AppFlowActionTranslationEntity $entity)
- * @method void set(AppFlowActionTranslationEntity $entity)
+ * @method void set(string $key, AppFlowActionTranslationEntity $entity)
  * @method AppFlowActionTranslationEntity[] getIterator()
  * @method AppFlowActionTranslationEntity[] getElements()
  * @method AppFlowActionTranslationEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class AppFlowActionTranslationCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return AppFlowActionTranslationEntity::class;
     }

--- a/src/Data/Entity/AppFlowEvent/AppFlowEventCollection.php
+++ b/src/Data/Entity/AppFlowEvent/AppFlowEventCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\AppFlowEvent;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(AppFlowEventEntity $entity)
- * @method void set(AppFlowEventEntity $entity)
+ * @method void set(string $key, AppFlowEventEntity $entity)
  * @method AppFlowEventEntity[] getIterator()
  * @method AppFlowEventEntity[] getElements()
  * @method AppFlowEventEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class AppFlowEventCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return AppFlowEventEntity::class;
     }

--- a/src/Data/Entity/AppPaymentMethod/AppPaymentMethodCollection.php
+++ b/src/Data/Entity/AppPaymentMethod/AppPaymentMethodCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\AppPaymentMethod;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(AppPaymentMethodEntity $entity)
- * @method void set(AppPaymentMethodEntity $entity)
+ * @method void set(string $key, AppPaymentMethodEntity $entity)
  * @method AppPaymentMethodEntity[] getIterator()
  * @method AppPaymentMethodEntity[] getElements()
  * @method AppPaymentMethodEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class AppPaymentMethodCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return AppPaymentMethodEntity::class;
     }

--- a/src/Data/Entity/AppScriptCondition/AppScriptConditionCollection.php
+++ b/src/Data/Entity/AppScriptCondition/AppScriptConditionCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\AppScriptCondition;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(AppScriptConditionEntity $entity)
- * @method void set(AppScriptConditionEntity $entity)
+ * @method void set(string $key, AppScriptConditionEntity $entity)
  * @method AppScriptConditionEntity[] getIterator()
  * @method AppScriptConditionEntity[] getElements()
  * @method AppScriptConditionEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class AppScriptConditionCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return AppScriptConditionEntity::class;
     }

--- a/src/Data/Entity/AppScriptConditionTranslation/AppScriptConditionTranslationCollection.php
+++ b/src/Data/Entity/AppScriptConditionTranslation/AppScriptConditionTranslationCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\AppScriptConditionTranslation;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(AppScriptConditionTranslationEntity $entity)
- * @method void set(AppScriptConditionTranslationEntity $entity)
+ * @method void set(string $key, AppScriptConditionTranslationEntity $entity)
  * @method AppScriptConditionTranslationEntity[] getIterator()
  * @method AppScriptConditionTranslationEntity[] getElements()
  * @method AppScriptConditionTranslationEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class AppScriptConditionTranslationCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return AppScriptConditionTranslationEntity::class;
     }

--- a/src/Data/Entity/AppShippingMethod/AppShippingMethodCollection.php
+++ b/src/Data/Entity/AppShippingMethod/AppShippingMethodCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\AppShippingMethod;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(AppShippingMethodEntity $entity)
- * @method void set(AppShippingMethodEntity $entity)
+ * @method void set(string $key, AppShippingMethodEntity $entity)
  * @method AppShippingMethodEntity[] getIterator()
  * @method AppShippingMethodEntity[] getElements()
  * @method AppShippingMethodEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class AppShippingMethodCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return AppShippingMethodEntity::class;
     }

--- a/src/Data/Entity/AppTemplate/AppTemplateCollection.php
+++ b/src/Data/Entity/AppTemplate/AppTemplateCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\AppTemplate;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(AppTemplateEntity $entity)
- * @method void set(AppTemplateEntity $entity)
+ * @method void set(string $key, AppTemplateEntity $entity)
  * @method AppTemplateEntity[] getIterator()
  * @method AppTemplateEntity[] getElements()
  * @method AppTemplateEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class AppTemplateCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return AppTemplateEntity::class;
     }

--- a/src/Data/Entity/AppTranslation/AppTranslationCollection.php
+++ b/src/Data/Entity/AppTranslation/AppTranslationCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\AppTranslation;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(AppTranslationEntity $entity)
- * @method void set(AppTranslationEntity $entity)
+ * @method void set(string $key, AppTranslationEntity $entity)
  * @method AppTranslationEntity[] getIterator()
  * @method AppTranslationEntity[] getElements()
  * @method AppTranslationEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class AppTranslationCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return AppTranslationEntity::class;
     }

--- a/src/Data/Entity/Category/CategoryCollection.php
+++ b/src/Data/Entity/Category/CategoryCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\Category;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(CategoryEntity $entity)
- * @method void set(CategoryEntity $entity)
+ * @method void set(string $key, CategoryEntity $entity)
  * @method CategoryEntity[] getIterator()
  * @method CategoryEntity[] getElements()
  * @method CategoryEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class CategoryCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return CategoryEntity::class;
     }

--- a/src/Data/Entity/CategoryTag/CategoryTagCollection.php
+++ b/src/Data/Entity/CategoryTag/CategoryTagCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\CategoryTag;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(CategoryTagEntity $entity)
- * @method void set(CategoryTagEntity $entity)
+ * @method void set(string $key, CategoryTagEntity $entity)
  * @method CategoryTagEntity[] getIterator()
  * @method CategoryTagEntity[] getElements()
  * @method CategoryTagEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class CategoryTagCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return CategoryTagEntity::class;
     }

--- a/src/Data/Entity/CategoryTranslation/CategoryTranslationCollection.php
+++ b/src/Data/Entity/CategoryTranslation/CategoryTranslationCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\CategoryTranslation;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(CategoryTranslationEntity $entity)
- * @method void set(CategoryTranslationEntity $entity)
+ * @method void set(string $key, CategoryTranslationEntity $entity)
  * @method CategoryTranslationEntity[] getIterator()
  * @method CategoryTranslationEntity[] getElements()
  * @method CategoryTranslationEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class CategoryTranslationCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return CategoryTranslationEntity::class;
     }

--- a/src/Data/Entity/CmsBlock/CmsBlockCollection.php
+++ b/src/Data/Entity/CmsBlock/CmsBlockCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\CmsBlock;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(CmsBlockEntity $entity)
- * @method void set(CmsBlockEntity $entity)
+ * @method void set(string $key, CmsBlockEntity $entity)
  * @method CmsBlockEntity[] getIterator()
  * @method CmsBlockEntity[] getElements()
  * @method CmsBlockEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class CmsBlockCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return CmsBlockEntity::class;
     }

--- a/src/Data/Entity/CmsPage/CmsPageCollection.php
+++ b/src/Data/Entity/CmsPage/CmsPageCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\CmsPage;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(CmsPageEntity $entity)
- * @method void set(CmsPageEntity $entity)
+ * @method void set(string $key, CmsPageEntity $entity)
  * @method CmsPageEntity[] getIterator()
  * @method CmsPageEntity[] getElements()
  * @method CmsPageEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class CmsPageCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return CmsPageEntity::class;
     }

--- a/src/Data/Entity/CmsPageTranslation/CmsPageTranslationCollection.php
+++ b/src/Data/Entity/CmsPageTranslation/CmsPageTranslationCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\CmsPageTranslation;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(CmsPageTranslationEntity $entity)
- * @method void set(CmsPageTranslationEntity $entity)
+ * @method void set(string $key, CmsPageTranslationEntity $entity)
  * @method CmsPageTranslationEntity[] getIterator()
  * @method CmsPageTranslationEntity[] getElements()
  * @method CmsPageTranslationEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class CmsPageTranslationCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return CmsPageTranslationEntity::class;
     }

--- a/src/Data/Entity/CmsSection/CmsSectionCollection.php
+++ b/src/Data/Entity/CmsSection/CmsSectionCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\CmsSection;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(CmsSectionEntity $entity)
- * @method void set(CmsSectionEntity $entity)
+ * @method void set(string $key, CmsSectionEntity $entity)
  * @method CmsSectionEntity[] getIterator()
  * @method CmsSectionEntity[] getElements()
  * @method CmsSectionEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class CmsSectionCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return CmsSectionEntity::class;
     }

--- a/src/Data/Entity/CmsSlot/CmsSlotCollection.php
+++ b/src/Data/Entity/CmsSlot/CmsSlotCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\CmsSlot;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(CmsSlotEntity $entity)
- * @method void set(CmsSlotEntity $entity)
+ * @method void set(string $key, CmsSlotEntity $entity)
  * @method CmsSlotEntity[] getIterator()
  * @method CmsSlotEntity[] getElements()
  * @method CmsSlotEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class CmsSlotCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return CmsSlotEntity::class;
     }

--- a/src/Data/Entity/CmsSlotTranslation/CmsSlotTranslationCollection.php
+++ b/src/Data/Entity/CmsSlotTranslation/CmsSlotTranslationCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\CmsSlotTranslation;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(CmsSlotTranslationEntity $entity)
- * @method void set(CmsSlotTranslationEntity $entity)
+ * @method void set(string $key, CmsSlotTranslationEntity $entity)
  * @method CmsSlotTranslationEntity[] getIterator()
  * @method CmsSlotTranslationEntity[] getElements()
  * @method CmsSlotTranslationEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class CmsSlotTranslationCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return CmsSlotTranslationEntity::class;
     }

--- a/src/Data/Entity/Country/CountryCollection.php
+++ b/src/Data/Entity/Country/CountryCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\Country;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(CountryEntity $entity)
- * @method void set(CountryEntity $entity)
+ * @method void set(string $key, CountryEntity $entity)
  * @method CountryEntity[] getIterator()
  * @method CountryEntity[] getElements()
  * @method CountryEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class CountryCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return CountryEntity::class;
     }

--- a/src/Data/Entity/CountryState/CountryStateCollection.php
+++ b/src/Data/Entity/CountryState/CountryStateCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\CountryState;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(CountryStateEntity $entity)
- * @method void set(CountryStateEntity $entity)
+ * @method void set(string $key, CountryStateEntity $entity)
  * @method CountryStateEntity[] getIterator()
  * @method CountryStateEntity[] getElements()
  * @method CountryStateEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class CountryStateCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return CountryStateEntity::class;
     }

--- a/src/Data/Entity/CountryStateTranslation/CountryStateTranslationCollection.php
+++ b/src/Data/Entity/CountryStateTranslation/CountryStateTranslationCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\CountryStateTranslation;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(CountryStateTranslationEntity $entity)
- * @method void set(CountryStateTranslationEntity $entity)
+ * @method void set(string $key, CountryStateTranslationEntity $entity)
  * @method CountryStateTranslationEntity[] getIterator()
  * @method CountryStateTranslationEntity[] getElements()
  * @method CountryStateTranslationEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class CountryStateTranslationCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return CountryStateTranslationEntity::class;
     }

--- a/src/Data/Entity/CountryTranslation/CountryTranslationCollection.php
+++ b/src/Data/Entity/CountryTranslation/CountryTranslationCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\CountryTranslation;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(CountryTranslationEntity $entity)
- * @method void set(CountryTranslationEntity $entity)
+ * @method void set(string $key, CountryTranslationEntity $entity)
  * @method CountryTranslationEntity[] getIterator()
  * @method CountryTranslationEntity[] getElements()
  * @method CountryTranslationEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class CountryTranslationCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return CountryTranslationEntity::class;
     }

--- a/src/Data/Entity/Currency/CurrencyCollection.php
+++ b/src/Data/Entity/Currency/CurrencyCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\Currency;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(CurrencyEntity $entity)
- * @method void set(CurrencyEntity $entity)
+ * @method void set(string $key, CurrencyEntity $entity)
  * @method CurrencyEntity[] getIterator()
  * @method CurrencyEntity[] getElements()
  * @method CurrencyEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class CurrencyCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return CurrencyEntity::class;
     }

--- a/src/Data/Entity/CurrencyCountryRounding/CurrencyCountryRoundingCollection.php
+++ b/src/Data/Entity/CurrencyCountryRounding/CurrencyCountryRoundingCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\CurrencyCountryRounding;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(CurrencyCountryRoundingEntity $entity)
- * @method void set(CurrencyCountryRoundingEntity $entity)
+ * @method void set(string $key, CurrencyCountryRoundingEntity $entity)
  * @method CurrencyCountryRoundingEntity[] getIterator()
  * @method CurrencyCountryRoundingEntity[] getElements()
  * @method CurrencyCountryRoundingEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class CurrencyCountryRoundingCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return CurrencyCountryRoundingEntity::class;
     }

--- a/src/Data/Entity/CurrencyTranslation/CurrencyTranslationCollection.php
+++ b/src/Data/Entity/CurrencyTranslation/CurrencyTranslationCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\CurrencyTranslation;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(CurrencyTranslationEntity $entity)
- * @method void set(CurrencyTranslationEntity $entity)
+ * @method void set(string $key, CurrencyTranslationEntity $entity)
  * @method CurrencyTranslationEntity[] getIterator()
  * @method CurrencyTranslationEntity[] getElements()
  * @method CurrencyTranslationEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class CurrencyTranslationCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return CurrencyTranslationEntity::class;
     }

--- a/src/Data/Entity/CustomEntity/CustomEntityCollection.php
+++ b/src/Data/Entity/CustomEntity/CustomEntityCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\CustomEntity;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(CustomEntityEntity $entity)
- * @method void set(CustomEntityEntity $entity)
+ * @method void set(string $key, CustomEntityEntity $entity)
  * @method CustomEntityEntity[] getIterator()
  * @method CustomEntityEntity[] getElements()
  * @method CustomEntityEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class CustomEntityCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return CustomEntityEntity::class;
     }

--- a/src/Data/Entity/CustomField/CustomFieldCollection.php
+++ b/src/Data/Entity/CustomField/CustomFieldCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\CustomField;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(CustomFieldEntity $entity)
- * @method void set(CustomFieldEntity $entity)
+ * @method void set(string $key, CustomFieldEntity $entity)
  * @method CustomFieldEntity[] getIterator()
  * @method CustomFieldEntity[] getElements()
  * @method CustomFieldEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class CustomFieldCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return CustomFieldEntity::class;
     }

--- a/src/Data/Entity/CustomFieldSet/CustomFieldSetCollection.php
+++ b/src/Data/Entity/CustomFieldSet/CustomFieldSetCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\CustomFieldSet;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(CustomFieldSetEntity $entity)
- * @method void set(CustomFieldSetEntity $entity)
+ * @method void set(string $key, CustomFieldSetEntity $entity)
  * @method CustomFieldSetEntity[] getIterator()
  * @method CustomFieldSetEntity[] getElements()
  * @method CustomFieldSetEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class CustomFieldSetCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return CustomFieldSetEntity::class;
     }

--- a/src/Data/Entity/CustomFieldSetRelation/CustomFieldSetRelationCollection.php
+++ b/src/Data/Entity/CustomFieldSetRelation/CustomFieldSetRelationCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\CustomFieldSetRelation;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(CustomFieldSetRelationEntity $entity)
- * @method void set(CustomFieldSetRelationEntity $entity)
+ * @method void set(string $key, CustomFieldSetRelationEntity $entity)
  * @method CustomFieldSetRelationEntity[] getIterator()
  * @method CustomFieldSetRelationEntity[] getElements()
  * @method CustomFieldSetRelationEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class CustomFieldSetRelationCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return CustomFieldSetRelationEntity::class;
     }

--- a/src/Data/Entity/Customer/CustomerCollection.php
+++ b/src/Data/Entity/Customer/CustomerCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\Customer;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(CustomerEntity $entity)
- * @method void set(CustomerEntity $entity)
+ * @method void set(string $key, CustomerEntity $entity)
  * @method CustomerEntity[] getIterator()
  * @method CustomerEntity[] getElements()
  * @method CustomerEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class CustomerCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return CustomerEntity::class;
     }

--- a/src/Data/Entity/CustomerAddress/CustomerAddressCollection.php
+++ b/src/Data/Entity/CustomerAddress/CustomerAddressCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\CustomerAddress;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(CustomerAddressEntity $entity)
- * @method void set(CustomerAddressEntity $entity)
+ * @method void set(string $key, CustomerAddressEntity $entity)
  * @method CustomerAddressEntity[] getIterator()
  * @method CustomerAddressEntity[] getElements()
  * @method CustomerAddressEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class CustomerAddressCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return CustomerAddressEntity::class;
     }

--- a/src/Data/Entity/CustomerGroup/CustomerGroupCollection.php
+++ b/src/Data/Entity/CustomerGroup/CustomerGroupCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\CustomerGroup;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(CustomerGroupEntity $entity)
- * @method void set(CustomerGroupEntity $entity)
+ * @method void set(string $key, CustomerGroupEntity $entity)
  * @method CustomerGroupEntity[] getIterator()
  * @method CustomerGroupEntity[] getElements()
  * @method CustomerGroupEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class CustomerGroupCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return CustomerGroupEntity::class;
     }

--- a/src/Data/Entity/CustomerGroupRegistrationSalesChannels/CustomerGroupRegistrationSalesChannelsCollection.php
+++ b/src/Data/Entity/CustomerGroupRegistrationSalesChannels/CustomerGroupRegistrationSalesChannelsCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\CustomerGroupRegistrationSalesChannels;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(CustomerGroupRegistrationSalesChannelsEntity $entity)
- * @method void set(CustomerGroupRegistrationSalesChannelsEntity $entity)
+ * @method void set(string $key, CustomerGroupRegistrationSalesChannelsEntity $entity)
  * @method CustomerGroupRegistrationSalesChannelsEntity[] getIterator()
  * @method CustomerGroupRegistrationSalesChannelsEntity[] getElements()
  * @method CustomerGroupRegistrationSalesChannelsEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class CustomerGroupRegistrationSalesChannelsCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return CustomerGroupRegistrationSalesChannelsEntity::class;
     }

--- a/src/Data/Entity/CustomerGroupTranslation/CustomerGroupTranslationCollection.php
+++ b/src/Data/Entity/CustomerGroupTranslation/CustomerGroupTranslationCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\CustomerGroupTranslation;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(CustomerGroupTranslationEntity $entity)
- * @method void set(CustomerGroupTranslationEntity $entity)
+ * @method void set(string $key, CustomerGroupTranslationEntity $entity)
  * @method CustomerGroupTranslationEntity[] getIterator()
  * @method CustomerGroupTranslationEntity[] getElements()
  * @method CustomerGroupTranslationEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class CustomerGroupTranslationCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return CustomerGroupTranslationEntity::class;
     }

--- a/src/Data/Entity/CustomerRecovery/CustomerRecoveryCollection.php
+++ b/src/Data/Entity/CustomerRecovery/CustomerRecoveryCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\CustomerRecovery;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(CustomerRecoveryEntity $entity)
- * @method void set(CustomerRecoveryEntity $entity)
+ * @method void set(string $key, CustomerRecoveryEntity $entity)
  * @method CustomerRecoveryEntity[] getIterator()
  * @method CustomerRecoveryEntity[] getElements()
  * @method CustomerRecoveryEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class CustomerRecoveryCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return CustomerRecoveryEntity::class;
     }

--- a/src/Data/Entity/CustomerTag/CustomerTagCollection.php
+++ b/src/Data/Entity/CustomerTag/CustomerTagCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\CustomerTag;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(CustomerTagEntity $entity)
- * @method void set(CustomerTagEntity $entity)
+ * @method void set(string $key, CustomerTagEntity $entity)
  * @method CustomerTagEntity[] getIterator()
  * @method CustomerTagEntity[] getElements()
  * @method CustomerTagEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class CustomerTagCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return CustomerTagEntity::class;
     }

--- a/src/Data/Entity/CustomerWishlist/CustomerWishlistCollection.php
+++ b/src/Data/Entity/CustomerWishlist/CustomerWishlistCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\CustomerWishlist;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(CustomerWishlistEntity $entity)
- * @method void set(CustomerWishlistEntity $entity)
+ * @method void set(string $key, CustomerWishlistEntity $entity)
  * @method CustomerWishlistEntity[] getIterator()
  * @method CustomerWishlistEntity[] getElements()
  * @method CustomerWishlistEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class CustomerWishlistCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return CustomerWishlistEntity::class;
     }

--- a/src/Data/Entity/CustomerWishlistProduct/CustomerWishlistProductCollection.php
+++ b/src/Data/Entity/CustomerWishlistProduct/CustomerWishlistProductCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\CustomerWishlistProduct;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(CustomerWishlistProductEntity $entity)
- * @method void set(CustomerWishlistProductEntity $entity)
+ * @method void set(string $key, CustomerWishlistProductEntity $entity)
  * @method CustomerWishlistProductEntity[] getIterator()
  * @method CustomerWishlistProductEntity[] getElements()
  * @method CustomerWishlistProductEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class CustomerWishlistProductCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return CustomerWishlistProductEntity::class;
     }

--- a/src/Data/Entity/DeliveryTime/DeliveryTimeCollection.php
+++ b/src/Data/Entity/DeliveryTime/DeliveryTimeCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\DeliveryTime;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(DeliveryTimeEntity $entity)
- * @method void set(DeliveryTimeEntity $entity)
+ * @method void set(string $key, DeliveryTimeEntity $entity)
  * @method DeliveryTimeEntity[] getIterator()
  * @method DeliveryTimeEntity[] getElements()
  * @method DeliveryTimeEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class DeliveryTimeCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return DeliveryTimeEntity::class;
     }

--- a/src/Data/Entity/DeliveryTimeTranslation/DeliveryTimeTranslationCollection.php
+++ b/src/Data/Entity/DeliveryTimeTranslation/DeliveryTimeTranslationCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\DeliveryTimeTranslation;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(DeliveryTimeTranslationEntity $entity)
- * @method void set(DeliveryTimeTranslationEntity $entity)
+ * @method void set(string $key, DeliveryTimeTranslationEntity $entity)
  * @method DeliveryTimeTranslationEntity[] getIterator()
  * @method DeliveryTimeTranslationEntity[] getElements()
  * @method DeliveryTimeTranslationEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class DeliveryTimeTranslationCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return DeliveryTimeTranslationEntity::class;
     }

--- a/src/Data/Entity/Document/DocumentCollection.php
+++ b/src/Data/Entity/Document/DocumentCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\Document;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(DocumentEntity $entity)
- * @method void set(DocumentEntity $entity)
+ * @method void set(string $key, DocumentEntity $entity)
  * @method DocumentEntity[] getIterator()
  * @method DocumentEntity[] getElements()
  * @method DocumentEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class DocumentCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return DocumentEntity::class;
     }

--- a/src/Data/Entity/DocumentBaseConfig/DocumentBaseConfigCollection.php
+++ b/src/Data/Entity/DocumentBaseConfig/DocumentBaseConfigCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\DocumentBaseConfig;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(DocumentBaseConfigEntity $entity)
- * @method void set(DocumentBaseConfigEntity $entity)
+ * @method void set(string $key, DocumentBaseConfigEntity $entity)
  * @method DocumentBaseConfigEntity[] getIterator()
  * @method DocumentBaseConfigEntity[] getElements()
  * @method DocumentBaseConfigEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class DocumentBaseConfigCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return DocumentBaseConfigEntity::class;
     }

--- a/src/Data/Entity/DocumentBaseConfigSalesChannel/DocumentBaseConfigSalesChannelCollection.php
+++ b/src/Data/Entity/DocumentBaseConfigSalesChannel/DocumentBaseConfigSalesChannelCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\DocumentBaseConfigSalesChannel;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(DocumentBaseConfigSalesChannelEntity $entity)
- * @method void set(DocumentBaseConfigSalesChannelEntity $entity)
+ * @method void set(string $key, DocumentBaseConfigSalesChannelEntity $entity)
  * @method DocumentBaseConfigSalesChannelEntity[] getIterator()
  * @method DocumentBaseConfigSalesChannelEntity[] getElements()
  * @method DocumentBaseConfigSalesChannelEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class DocumentBaseConfigSalesChannelCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return DocumentBaseConfigSalesChannelEntity::class;
     }

--- a/src/Data/Entity/DocumentType/DocumentTypeCollection.php
+++ b/src/Data/Entity/DocumentType/DocumentTypeCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\DocumentType;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(DocumentTypeEntity $entity)
- * @method void set(DocumentTypeEntity $entity)
+ * @method void set(string $key, DocumentTypeEntity $entity)
  * @method DocumentTypeEntity[] getIterator()
  * @method DocumentTypeEntity[] getElements()
  * @method DocumentTypeEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class DocumentTypeCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return DocumentTypeEntity::class;
     }

--- a/src/Data/Entity/DocumentTypeTranslation/DocumentTypeTranslationCollection.php
+++ b/src/Data/Entity/DocumentTypeTranslation/DocumentTypeTranslationCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\DocumentTypeTranslation;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(DocumentTypeTranslationEntity $entity)
- * @method void set(DocumentTypeTranslationEntity $entity)
+ * @method void set(string $key, DocumentTypeTranslationEntity $entity)
  * @method DocumentTypeTranslationEntity[] getIterator()
  * @method DocumentTypeTranslationEntity[] getElements()
  * @method DocumentTypeTranslationEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class DocumentTypeTranslationCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return DocumentTypeTranslationEntity::class;
     }

--- a/src/Data/Entity/Flow/FlowCollection.php
+++ b/src/Data/Entity/Flow/FlowCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\Flow;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(FlowEntity $entity)
- * @method void set(FlowEntity $entity)
+ * @method void set(string $key, FlowEntity $entity)
  * @method FlowEntity[] getIterator()
  * @method FlowEntity[] getElements()
  * @method FlowEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class FlowCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return FlowEntity::class;
     }

--- a/src/Data/Entity/FlowSequence/FlowSequenceCollection.php
+++ b/src/Data/Entity/FlowSequence/FlowSequenceCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\FlowSequence;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(FlowSequenceEntity $entity)
- * @method void set(FlowSequenceEntity $entity)
+ * @method void set(string $key, FlowSequenceEntity $entity)
  * @method FlowSequenceEntity[] getIterator()
  * @method FlowSequenceEntity[] getElements()
  * @method FlowSequenceEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class FlowSequenceCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return FlowSequenceEntity::class;
     }

--- a/src/Data/Entity/FlowTemplate/FlowTemplateCollection.php
+++ b/src/Data/Entity/FlowTemplate/FlowTemplateCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\FlowTemplate;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(FlowTemplateEntity $entity)
- * @method void set(FlowTemplateEntity $entity)
+ * @method void set(string $key, FlowTemplateEntity $entity)
  * @method FlowTemplateEntity[] getIterator()
  * @method FlowTemplateEntity[] getElements()
  * @method FlowTemplateEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class FlowTemplateCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return FlowTemplateEntity::class;
     }

--- a/src/Data/Entity/ImportExportFile/ImportExportFileCollection.php
+++ b/src/Data/Entity/ImportExportFile/ImportExportFileCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\ImportExportFile;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(ImportExportFileEntity $entity)
- * @method void set(ImportExportFileEntity $entity)
+ * @method void set(string $key, ImportExportFileEntity $entity)
  * @method ImportExportFileEntity[] getIterator()
  * @method ImportExportFileEntity[] getElements()
  * @method ImportExportFileEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class ImportExportFileCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return ImportExportFileEntity::class;
     }

--- a/src/Data/Entity/ImportExportLog/ImportExportLogCollection.php
+++ b/src/Data/Entity/ImportExportLog/ImportExportLogCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\ImportExportLog;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(ImportExportLogEntity $entity)
- * @method void set(ImportExportLogEntity $entity)
+ * @method void set(string $key, ImportExportLogEntity $entity)
  * @method ImportExportLogEntity[] getIterator()
  * @method ImportExportLogEntity[] getElements()
  * @method ImportExportLogEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class ImportExportLogCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return ImportExportLogEntity::class;
     }

--- a/src/Data/Entity/ImportExportProfile/ImportExportProfileCollection.php
+++ b/src/Data/Entity/ImportExportProfile/ImportExportProfileCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\ImportExportProfile;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(ImportExportProfileEntity $entity)
- * @method void set(ImportExportProfileEntity $entity)
+ * @method void set(string $key, ImportExportProfileEntity $entity)
  * @method ImportExportProfileEntity[] getIterator()
  * @method ImportExportProfileEntity[] getElements()
  * @method ImportExportProfileEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class ImportExportProfileCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return ImportExportProfileEntity::class;
     }

--- a/src/Data/Entity/ImportExportProfileTranslation/ImportExportProfileTranslationCollection.php
+++ b/src/Data/Entity/ImportExportProfileTranslation/ImportExportProfileTranslationCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\ImportExportProfileTranslation;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(ImportExportProfileTranslationEntity $entity)
- * @method void set(ImportExportProfileTranslationEntity $entity)
+ * @method void set(string $key, ImportExportProfileTranslationEntity $entity)
  * @method ImportExportProfileTranslationEntity[] getIterator()
  * @method ImportExportProfileTranslationEntity[] getElements()
  * @method ImportExportProfileTranslationEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class ImportExportProfileTranslationCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return ImportExportProfileTranslationEntity::class;
     }

--- a/src/Data/Entity/Integration/IntegrationCollection.php
+++ b/src/Data/Entity/Integration/IntegrationCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\Integration;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(IntegrationEntity $entity)
- * @method void set(IntegrationEntity $entity)
+ * @method void set(string $key, IntegrationEntity $entity)
  * @method IntegrationEntity[] getIterator()
  * @method IntegrationEntity[] getElements()
  * @method IntegrationEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class IntegrationCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return IntegrationEntity::class;
     }

--- a/src/Data/Entity/IntegrationRole/IntegrationRoleCollection.php
+++ b/src/Data/Entity/IntegrationRole/IntegrationRoleCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\IntegrationRole;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(IntegrationRoleEntity $entity)
- * @method void set(IntegrationRoleEntity $entity)
+ * @method void set(string $key, IntegrationRoleEntity $entity)
  * @method IntegrationRoleEntity[] getIterator()
  * @method IntegrationRoleEntity[] getElements()
  * @method IntegrationRoleEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class IntegrationRoleCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return IntegrationRoleEntity::class;
     }

--- a/src/Data/Entity/LandingPage/LandingPageCollection.php
+++ b/src/Data/Entity/LandingPage/LandingPageCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\LandingPage;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(LandingPageEntity $entity)
- * @method void set(LandingPageEntity $entity)
+ * @method void set(string $key, LandingPageEntity $entity)
  * @method LandingPageEntity[] getIterator()
  * @method LandingPageEntity[] getElements()
  * @method LandingPageEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class LandingPageCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return LandingPageEntity::class;
     }

--- a/src/Data/Entity/LandingPageSalesChannel/LandingPageSalesChannelCollection.php
+++ b/src/Data/Entity/LandingPageSalesChannel/LandingPageSalesChannelCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\LandingPageSalesChannel;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(LandingPageSalesChannelEntity $entity)
- * @method void set(LandingPageSalesChannelEntity $entity)
+ * @method void set(string $key, LandingPageSalesChannelEntity $entity)
  * @method LandingPageSalesChannelEntity[] getIterator()
  * @method LandingPageSalesChannelEntity[] getElements()
  * @method LandingPageSalesChannelEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class LandingPageSalesChannelCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return LandingPageSalesChannelEntity::class;
     }

--- a/src/Data/Entity/LandingPageTag/LandingPageTagCollection.php
+++ b/src/Data/Entity/LandingPageTag/LandingPageTagCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\LandingPageTag;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(LandingPageTagEntity $entity)
- * @method void set(LandingPageTagEntity $entity)
+ * @method void set(string $key, LandingPageTagEntity $entity)
  * @method LandingPageTagEntity[] getIterator()
  * @method LandingPageTagEntity[] getElements()
  * @method LandingPageTagEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class LandingPageTagCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return LandingPageTagEntity::class;
     }

--- a/src/Data/Entity/LandingPageTranslation/LandingPageTranslationCollection.php
+++ b/src/Data/Entity/LandingPageTranslation/LandingPageTranslationCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\LandingPageTranslation;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(LandingPageTranslationEntity $entity)
- * @method void set(LandingPageTranslationEntity $entity)
+ * @method void set(string $key, LandingPageTranslationEntity $entity)
  * @method LandingPageTranslationEntity[] getIterator()
  * @method LandingPageTranslationEntity[] getElements()
  * @method LandingPageTranslationEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class LandingPageTranslationCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return LandingPageTranslationEntity::class;
     }

--- a/src/Data/Entity/Language/LanguageCollection.php
+++ b/src/Data/Entity/Language/LanguageCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\Language;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(LanguageEntity $entity)
- * @method void set(LanguageEntity $entity)
+ * @method void set(string $key, LanguageEntity $entity)
  * @method LanguageEntity[] getIterator()
  * @method LanguageEntity[] getElements()
  * @method LanguageEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class LanguageCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return LanguageEntity::class;
     }

--- a/src/Data/Entity/Locale/LocaleCollection.php
+++ b/src/Data/Entity/Locale/LocaleCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\Locale;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(LocaleEntity $entity)
- * @method void set(LocaleEntity $entity)
+ * @method void set(string $key, LocaleEntity $entity)
  * @method LocaleEntity[] getIterator()
  * @method LocaleEntity[] getElements()
  * @method LocaleEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class LocaleCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return LocaleEntity::class;
     }

--- a/src/Data/Entity/LocaleTranslation/LocaleTranslationCollection.php
+++ b/src/Data/Entity/LocaleTranslation/LocaleTranslationCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\LocaleTranslation;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(LocaleTranslationEntity $entity)
- * @method void set(LocaleTranslationEntity $entity)
+ * @method void set(string $key, LocaleTranslationEntity $entity)
  * @method LocaleTranslationEntity[] getIterator()
  * @method LocaleTranslationEntity[] getElements()
  * @method LocaleTranslationEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class LocaleTranslationCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return LocaleTranslationEntity::class;
     }

--- a/src/Data/Entity/LogEntry/LogEntryCollection.php
+++ b/src/Data/Entity/LogEntry/LogEntryCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\LogEntry;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(LogEntryEntity $entity)
- * @method void set(LogEntryEntity $entity)
+ * @method void set(string $key, LogEntryEntity $entity)
  * @method LogEntryEntity[] getIterator()
  * @method LogEntryEntity[] getElements()
  * @method LogEntryEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class LogEntryCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return LogEntryEntity::class;
     }

--- a/src/Data/Entity/MailHeaderFooter/MailHeaderFooterCollection.php
+++ b/src/Data/Entity/MailHeaderFooter/MailHeaderFooterCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\MailHeaderFooter;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(MailHeaderFooterEntity $entity)
- * @method void set(MailHeaderFooterEntity $entity)
+ * @method void set(string $key, MailHeaderFooterEntity $entity)
  * @method MailHeaderFooterEntity[] getIterator()
  * @method MailHeaderFooterEntity[] getElements()
  * @method MailHeaderFooterEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class MailHeaderFooterCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return MailHeaderFooterEntity::class;
     }

--- a/src/Data/Entity/MailHeaderFooterTranslation/MailHeaderFooterTranslationCollection.php
+++ b/src/Data/Entity/MailHeaderFooterTranslation/MailHeaderFooterTranslationCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\MailHeaderFooterTranslation;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(MailHeaderFooterTranslationEntity $entity)
- * @method void set(MailHeaderFooterTranslationEntity $entity)
+ * @method void set(string $key, MailHeaderFooterTranslationEntity $entity)
  * @method MailHeaderFooterTranslationEntity[] getIterator()
  * @method MailHeaderFooterTranslationEntity[] getElements()
  * @method MailHeaderFooterTranslationEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class MailHeaderFooterTranslationCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return MailHeaderFooterTranslationEntity::class;
     }

--- a/src/Data/Entity/MailTemplate/MailTemplateCollection.php
+++ b/src/Data/Entity/MailTemplate/MailTemplateCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\MailTemplate;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(MailTemplateEntity $entity)
- * @method void set(MailTemplateEntity $entity)
+ * @method void set(string $key, MailTemplateEntity $entity)
  * @method MailTemplateEntity[] getIterator()
  * @method MailTemplateEntity[] getElements()
  * @method MailTemplateEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class MailTemplateCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return MailTemplateEntity::class;
     }

--- a/src/Data/Entity/MailTemplateMedia/MailTemplateMediaCollection.php
+++ b/src/Data/Entity/MailTemplateMedia/MailTemplateMediaCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\MailTemplateMedia;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(MailTemplateMediaEntity $entity)
- * @method void set(MailTemplateMediaEntity $entity)
+ * @method void set(string $key, MailTemplateMediaEntity $entity)
  * @method MailTemplateMediaEntity[] getIterator()
  * @method MailTemplateMediaEntity[] getElements()
  * @method MailTemplateMediaEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class MailTemplateMediaCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return MailTemplateMediaEntity::class;
     }

--- a/src/Data/Entity/MailTemplateTranslation/MailTemplateTranslationCollection.php
+++ b/src/Data/Entity/MailTemplateTranslation/MailTemplateTranslationCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\MailTemplateTranslation;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(MailTemplateTranslationEntity $entity)
- * @method void set(MailTemplateTranslationEntity $entity)
+ * @method void set(string $key, MailTemplateTranslationEntity $entity)
  * @method MailTemplateTranslationEntity[] getIterator()
  * @method MailTemplateTranslationEntity[] getElements()
  * @method MailTemplateTranslationEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class MailTemplateTranslationCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return MailTemplateTranslationEntity::class;
     }

--- a/src/Data/Entity/MailTemplateType/MailTemplateTypeCollection.php
+++ b/src/Data/Entity/MailTemplateType/MailTemplateTypeCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\MailTemplateType;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(MailTemplateTypeEntity $entity)
- * @method void set(MailTemplateTypeEntity $entity)
+ * @method void set(string $key, MailTemplateTypeEntity $entity)
  * @method MailTemplateTypeEntity[] getIterator()
  * @method MailTemplateTypeEntity[] getElements()
  * @method MailTemplateTypeEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class MailTemplateTypeCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return MailTemplateTypeEntity::class;
     }

--- a/src/Data/Entity/MailTemplateTypeTranslation/MailTemplateTypeTranslationCollection.php
+++ b/src/Data/Entity/MailTemplateTypeTranslation/MailTemplateTypeTranslationCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\MailTemplateTypeTranslation;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(MailTemplateTypeTranslationEntity $entity)
- * @method void set(MailTemplateTypeTranslationEntity $entity)
+ * @method void set(string $key, MailTemplateTypeTranslationEntity $entity)
  * @method MailTemplateTypeTranslationEntity[] getIterator()
  * @method MailTemplateTypeTranslationEntity[] getElements()
  * @method MailTemplateTypeTranslationEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class MailTemplateTypeTranslationCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return MailTemplateTypeTranslationEntity::class;
     }

--- a/src/Data/Entity/MainCategory/MainCategoryCollection.php
+++ b/src/Data/Entity/MainCategory/MainCategoryCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\MainCategory;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(MainCategoryEntity $entity)
- * @method void set(MainCategoryEntity $entity)
+ * @method void set(string $key, MainCategoryEntity $entity)
  * @method MainCategoryEntity[] getIterator()
  * @method MainCategoryEntity[] getElements()
  * @method MainCategoryEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class MainCategoryCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return MainCategoryEntity::class;
     }

--- a/src/Data/Entity/Media/MediaCollection.php
+++ b/src/Data/Entity/Media/MediaCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\Media;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(MediaEntity $entity)
- * @method void set(MediaEntity $entity)
+ * @method void set(string $key, MediaEntity $entity)
  * @method MediaEntity[] getIterator()
  * @method MediaEntity[] getElements()
  * @method MediaEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class MediaCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return MediaEntity::class;
     }

--- a/src/Data/Entity/MediaDefaultFolder/MediaDefaultFolderCollection.php
+++ b/src/Data/Entity/MediaDefaultFolder/MediaDefaultFolderCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\MediaDefaultFolder;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(MediaDefaultFolderEntity $entity)
- * @method void set(MediaDefaultFolderEntity $entity)
+ * @method void set(string $key, MediaDefaultFolderEntity $entity)
  * @method MediaDefaultFolderEntity[] getIterator()
  * @method MediaDefaultFolderEntity[] getElements()
  * @method MediaDefaultFolderEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class MediaDefaultFolderCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return MediaDefaultFolderEntity::class;
     }

--- a/src/Data/Entity/MediaFolder/MediaFolderCollection.php
+++ b/src/Data/Entity/MediaFolder/MediaFolderCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\MediaFolder;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(MediaFolderEntity $entity)
- * @method void set(MediaFolderEntity $entity)
+ * @method void set(string $key, MediaFolderEntity $entity)
  * @method MediaFolderEntity[] getIterator()
  * @method MediaFolderEntity[] getElements()
  * @method MediaFolderEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class MediaFolderCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return MediaFolderEntity::class;
     }

--- a/src/Data/Entity/MediaFolderConfiguration/MediaFolderConfigurationCollection.php
+++ b/src/Data/Entity/MediaFolderConfiguration/MediaFolderConfigurationCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\MediaFolderConfiguration;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(MediaFolderConfigurationEntity $entity)
- * @method void set(MediaFolderConfigurationEntity $entity)
+ * @method void set(string $key, MediaFolderConfigurationEntity $entity)
  * @method MediaFolderConfigurationEntity[] getIterator()
  * @method MediaFolderConfigurationEntity[] getElements()
  * @method MediaFolderConfigurationEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class MediaFolderConfigurationCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return MediaFolderConfigurationEntity::class;
     }

--- a/src/Data/Entity/MediaFolderConfigurationMediaThumbnailSize/MediaFolderConfigurationMediaThumbnailSizeCollection.php
+++ b/src/Data/Entity/MediaFolderConfigurationMediaThumbnailSize/MediaFolderConfigurationMediaThumbnailSizeCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\MediaFolderConfigurationMediaThumbnailSize;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(MediaFolderConfigurationMediaThumbnailSizeEntity $entity)
- * @method void set(MediaFolderConfigurationMediaThumbnailSizeEntity $entity)
+ * @method void set(string $key, MediaFolderConfigurationMediaThumbnailSizeEntity $entity)
  * @method MediaFolderConfigurationMediaThumbnailSizeEntity[] getIterator()
  * @method MediaFolderConfigurationMediaThumbnailSizeEntity[] getElements()
  * @method MediaFolderConfigurationMediaThumbnailSizeEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class MediaFolderConfigurationMediaThumbnailSizeCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return MediaFolderConfigurationMediaThumbnailSizeEntity::class;
     }

--- a/src/Data/Entity/MediaTag/MediaTagCollection.php
+++ b/src/Data/Entity/MediaTag/MediaTagCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\MediaTag;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(MediaTagEntity $entity)
- * @method void set(MediaTagEntity $entity)
+ * @method void set(string $key, MediaTagEntity $entity)
  * @method MediaTagEntity[] getIterator()
  * @method MediaTagEntity[] getElements()
  * @method MediaTagEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class MediaTagCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return MediaTagEntity::class;
     }

--- a/src/Data/Entity/MediaThumbnail/MediaThumbnailCollection.php
+++ b/src/Data/Entity/MediaThumbnail/MediaThumbnailCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\MediaThumbnail;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(MediaThumbnailEntity $entity)
- * @method void set(MediaThumbnailEntity $entity)
+ * @method void set(string $key, MediaThumbnailEntity $entity)
  * @method MediaThumbnailEntity[] getIterator()
  * @method MediaThumbnailEntity[] getElements()
  * @method MediaThumbnailEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class MediaThumbnailCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return MediaThumbnailEntity::class;
     }

--- a/src/Data/Entity/MediaThumbnailSize/MediaThumbnailSizeCollection.php
+++ b/src/Data/Entity/MediaThumbnailSize/MediaThumbnailSizeCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\MediaThumbnailSize;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(MediaThumbnailSizeEntity $entity)
- * @method void set(MediaThumbnailSizeEntity $entity)
+ * @method void set(string $key, MediaThumbnailSizeEntity $entity)
  * @method MediaThumbnailSizeEntity[] getIterator()
  * @method MediaThumbnailSizeEntity[] getElements()
  * @method MediaThumbnailSizeEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class MediaThumbnailSizeCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return MediaThumbnailSizeEntity::class;
     }

--- a/src/Data/Entity/MediaTranslation/MediaTranslationCollection.php
+++ b/src/Data/Entity/MediaTranslation/MediaTranslationCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\MediaTranslation;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(MediaTranslationEntity $entity)
- * @method void set(MediaTranslationEntity $entity)
+ * @method void set(string $key, MediaTranslationEntity $entity)
  * @method MediaTranslationEntity[] getIterator()
  * @method MediaTranslationEntity[] getElements()
  * @method MediaTranslationEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class MediaTranslationCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return MediaTranslationEntity::class;
     }

--- a/src/Data/Entity/NewsletterRecipient/NewsletterRecipientCollection.php
+++ b/src/Data/Entity/NewsletterRecipient/NewsletterRecipientCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\NewsletterRecipient;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(NewsletterRecipientEntity $entity)
- * @method void set(NewsletterRecipientEntity $entity)
+ * @method void set(string $key, NewsletterRecipientEntity $entity)
  * @method NewsletterRecipientEntity[] getIterator()
  * @method NewsletterRecipientEntity[] getElements()
  * @method NewsletterRecipientEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class NewsletterRecipientCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return NewsletterRecipientEntity::class;
     }

--- a/src/Data/Entity/NewsletterRecipientTag/NewsletterRecipientTagCollection.php
+++ b/src/Data/Entity/NewsletterRecipientTag/NewsletterRecipientTagCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\NewsletterRecipientTag;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(NewsletterRecipientTagEntity $entity)
- * @method void set(NewsletterRecipientTagEntity $entity)
+ * @method void set(string $key, NewsletterRecipientTagEntity $entity)
  * @method NewsletterRecipientTagEntity[] getIterator()
  * @method NewsletterRecipientTagEntity[] getElements()
  * @method NewsletterRecipientTagEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class NewsletterRecipientTagCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return NewsletterRecipientTagEntity::class;
     }

--- a/src/Data/Entity/Notification/NotificationCollection.php
+++ b/src/Data/Entity/Notification/NotificationCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\Notification;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(NotificationEntity $entity)
- * @method void set(NotificationEntity $entity)
+ * @method void set(string $key, NotificationEntity $entity)
  * @method NotificationEntity[] getIterator()
  * @method NotificationEntity[] getElements()
  * @method NotificationEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class NotificationCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return NotificationEntity::class;
     }

--- a/src/Data/Entity/NumberRange/NumberRangeCollection.php
+++ b/src/Data/Entity/NumberRange/NumberRangeCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\NumberRange;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(NumberRangeEntity $entity)
- * @method void set(NumberRangeEntity $entity)
+ * @method void set(string $key, NumberRangeEntity $entity)
  * @method NumberRangeEntity[] getIterator()
  * @method NumberRangeEntity[] getElements()
  * @method NumberRangeEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class NumberRangeCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return NumberRangeEntity::class;
     }

--- a/src/Data/Entity/NumberRangeSalesChannel/NumberRangeSalesChannelCollection.php
+++ b/src/Data/Entity/NumberRangeSalesChannel/NumberRangeSalesChannelCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\NumberRangeSalesChannel;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(NumberRangeSalesChannelEntity $entity)
- * @method void set(NumberRangeSalesChannelEntity $entity)
+ * @method void set(string $key, NumberRangeSalesChannelEntity $entity)
  * @method NumberRangeSalesChannelEntity[] getIterator()
  * @method NumberRangeSalesChannelEntity[] getElements()
  * @method NumberRangeSalesChannelEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class NumberRangeSalesChannelCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return NumberRangeSalesChannelEntity::class;
     }

--- a/src/Data/Entity/NumberRangeState/NumberRangeStateCollection.php
+++ b/src/Data/Entity/NumberRangeState/NumberRangeStateCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\NumberRangeState;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(NumberRangeStateEntity $entity)
- * @method void set(NumberRangeStateEntity $entity)
+ * @method void set(string $key, NumberRangeStateEntity $entity)
  * @method NumberRangeStateEntity[] getIterator()
  * @method NumberRangeStateEntity[] getElements()
  * @method NumberRangeStateEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class NumberRangeStateCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return NumberRangeStateEntity::class;
     }

--- a/src/Data/Entity/NumberRangeTranslation/NumberRangeTranslationCollection.php
+++ b/src/Data/Entity/NumberRangeTranslation/NumberRangeTranslationCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\NumberRangeTranslation;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(NumberRangeTranslationEntity $entity)
- * @method void set(NumberRangeTranslationEntity $entity)
+ * @method void set(string $key, NumberRangeTranslationEntity $entity)
  * @method NumberRangeTranslationEntity[] getIterator()
  * @method NumberRangeTranslationEntity[] getElements()
  * @method NumberRangeTranslationEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class NumberRangeTranslationCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return NumberRangeTranslationEntity::class;
     }

--- a/src/Data/Entity/NumberRangeType/NumberRangeTypeCollection.php
+++ b/src/Data/Entity/NumberRangeType/NumberRangeTypeCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\NumberRangeType;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(NumberRangeTypeEntity $entity)
- * @method void set(NumberRangeTypeEntity $entity)
+ * @method void set(string $key, NumberRangeTypeEntity $entity)
  * @method NumberRangeTypeEntity[] getIterator()
  * @method NumberRangeTypeEntity[] getElements()
  * @method NumberRangeTypeEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class NumberRangeTypeCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return NumberRangeTypeEntity::class;
     }

--- a/src/Data/Entity/NumberRangeTypeTranslation/NumberRangeTypeTranslationCollection.php
+++ b/src/Data/Entity/NumberRangeTypeTranslation/NumberRangeTypeTranslationCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\NumberRangeTypeTranslation;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(NumberRangeTypeTranslationEntity $entity)
- * @method void set(NumberRangeTypeTranslationEntity $entity)
+ * @method void set(string $key, NumberRangeTypeTranslationEntity $entity)
  * @method NumberRangeTypeTranslationEntity[] getIterator()
  * @method NumberRangeTypeTranslationEntity[] getElements()
  * @method NumberRangeTypeTranslationEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class NumberRangeTypeTranslationCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return NumberRangeTypeTranslationEntity::class;
     }

--- a/src/Data/Entity/Order/OrderCollection.php
+++ b/src/Data/Entity/Order/OrderCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\Order;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(OrderEntity $entity)
- * @method void set(OrderEntity $entity)
+ * @method void set(string $key, OrderEntity $entity)
  * @method OrderEntity[] getIterator()
  * @method OrderEntity[] getElements()
  * @method OrderEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class OrderCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return OrderEntity::class;
     }

--- a/src/Data/Entity/OrderAddress/OrderAddressCollection.php
+++ b/src/Data/Entity/OrderAddress/OrderAddressCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\OrderAddress;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(OrderAddressEntity $entity)
- * @method void set(OrderAddressEntity $entity)
+ * @method void set(string $key, OrderAddressEntity $entity)
  * @method OrderAddressEntity[] getIterator()
  * @method OrderAddressEntity[] getElements()
  * @method OrderAddressEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class OrderAddressCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return OrderAddressEntity::class;
     }

--- a/src/Data/Entity/OrderCustomer/OrderCustomerCollection.php
+++ b/src/Data/Entity/OrderCustomer/OrderCustomerCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\OrderCustomer;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(OrderCustomerEntity $entity)
- * @method void set(OrderCustomerEntity $entity)
+ * @method void set(string $key, OrderCustomerEntity $entity)
  * @method OrderCustomerEntity[] getIterator()
  * @method OrderCustomerEntity[] getElements()
  * @method OrderCustomerEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class OrderCustomerCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return OrderCustomerEntity::class;
     }

--- a/src/Data/Entity/OrderDelivery/OrderDeliveryCollection.php
+++ b/src/Data/Entity/OrderDelivery/OrderDeliveryCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\OrderDelivery;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(OrderDeliveryEntity $entity)
- * @method void set(OrderDeliveryEntity $entity)
+ * @method void set(string $key, OrderDeliveryEntity $entity)
  * @method OrderDeliveryEntity[] getIterator()
  * @method OrderDeliveryEntity[] getElements()
  * @method OrderDeliveryEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class OrderDeliveryCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return OrderDeliveryEntity::class;
     }

--- a/src/Data/Entity/OrderDeliveryPosition/OrderDeliveryPositionCollection.php
+++ b/src/Data/Entity/OrderDeliveryPosition/OrderDeliveryPositionCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\OrderDeliveryPosition;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(OrderDeliveryPositionEntity $entity)
- * @method void set(OrderDeliveryPositionEntity $entity)
+ * @method void set(string $key, OrderDeliveryPositionEntity $entity)
  * @method OrderDeliveryPositionEntity[] getIterator()
  * @method OrderDeliveryPositionEntity[] getElements()
  * @method OrderDeliveryPositionEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class OrderDeliveryPositionCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return OrderDeliveryPositionEntity::class;
     }

--- a/src/Data/Entity/OrderLineItem/OrderLineItemCollection.php
+++ b/src/Data/Entity/OrderLineItem/OrderLineItemCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\OrderLineItem;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(OrderLineItemEntity $entity)
- * @method void set(OrderLineItemEntity $entity)
+ * @method void set(string $key, OrderLineItemEntity $entity)
  * @method OrderLineItemEntity[] getIterator()
  * @method OrderLineItemEntity[] getElements()
  * @method OrderLineItemEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class OrderLineItemCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return OrderLineItemEntity::class;
     }

--- a/src/Data/Entity/OrderLineItemDownload/OrderLineItemDownloadCollection.php
+++ b/src/Data/Entity/OrderLineItemDownload/OrderLineItemDownloadCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\OrderLineItemDownload;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(OrderLineItemDownloadEntity $entity)
- * @method void set(OrderLineItemDownloadEntity $entity)
+ * @method void set(string $key, OrderLineItemDownloadEntity $entity)
  * @method OrderLineItemDownloadEntity[] getIterator()
  * @method OrderLineItemDownloadEntity[] getElements()
  * @method OrderLineItemDownloadEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class OrderLineItemDownloadCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return OrderLineItemDownloadEntity::class;
     }

--- a/src/Data/Entity/OrderTag/OrderTagCollection.php
+++ b/src/Data/Entity/OrderTag/OrderTagCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\OrderTag;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(OrderTagEntity $entity)
- * @method void set(OrderTagEntity $entity)
+ * @method void set(string $key, OrderTagEntity $entity)
  * @method OrderTagEntity[] getIterator()
  * @method OrderTagEntity[] getElements()
  * @method OrderTagEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class OrderTagCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return OrderTagEntity::class;
     }

--- a/src/Data/Entity/OrderTransaction/OrderTransactionCollection.php
+++ b/src/Data/Entity/OrderTransaction/OrderTransactionCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\OrderTransaction;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(OrderTransactionEntity $entity)
- * @method void set(OrderTransactionEntity $entity)
+ * @method void set(string $key, OrderTransactionEntity $entity)
  * @method OrderTransactionEntity[] getIterator()
  * @method OrderTransactionEntity[] getElements()
  * @method OrderTransactionEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class OrderTransactionCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return OrderTransactionEntity::class;
     }

--- a/src/Data/Entity/OrderTransactionCapture/OrderTransactionCaptureCollection.php
+++ b/src/Data/Entity/OrderTransactionCapture/OrderTransactionCaptureCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\OrderTransactionCapture;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(OrderTransactionCaptureEntity $entity)
- * @method void set(OrderTransactionCaptureEntity $entity)
+ * @method void set(string $key, OrderTransactionCaptureEntity $entity)
  * @method OrderTransactionCaptureEntity[] getIterator()
  * @method OrderTransactionCaptureEntity[] getElements()
  * @method OrderTransactionCaptureEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class OrderTransactionCaptureCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return OrderTransactionCaptureEntity::class;
     }

--- a/src/Data/Entity/OrderTransactionCaptureRefund/OrderTransactionCaptureRefundCollection.php
+++ b/src/Data/Entity/OrderTransactionCaptureRefund/OrderTransactionCaptureRefundCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\OrderTransactionCaptureRefund;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(OrderTransactionCaptureRefundEntity $entity)
- * @method void set(OrderTransactionCaptureRefundEntity $entity)
+ * @method void set(string $key, OrderTransactionCaptureRefundEntity $entity)
  * @method OrderTransactionCaptureRefundEntity[] getIterator()
  * @method OrderTransactionCaptureRefundEntity[] getElements()
  * @method OrderTransactionCaptureRefundEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class OrderTransactionCaptureRefundCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return OrderTransactionCaptureRefundEntity::class;
     }

--- a/src/Data/Entity/OrderTransactionCaptureRefundPosition/OrderTransactionCaptureRefundPositionCollection.php
+++ b/src/Data/Entity/OrderTransactionCaptureRefundPosition/OrderTransactionCaptureRefundPositionCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\OrderTransactionCaptureRefundPosition;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(OrderTransactionCaptureRefundPositionEntity $entity)
- * @method void set(OrderTransactionCaptureRefundPositionEntity $entity)
+ * @method void set(string $key, OrderTransactionCaptureRefundPositionEntity $entity)
  * @method OrderTransactionCaptureRefundPositionEntity[] getIterator()
  * @method OrderTransactionCaptureRefundPositionEntity[] getElements()
  * @method OrderTransactionCaptureRefundPositionEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class OrderTransactionCaptureRefundPositionCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return OrderTransactionCaptureRefundPositionEntity::class;
     }

--- a/src/Data/Entity/PaymentMethod/PaymentMethodCollection.php
+++ b/src/Data/Entity/PaymentMethod/PaymentMethodCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\PaymentMethod;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(PaymentMethodEntity $entity)
- * @method void set(PaymentMethodEntity $entity)
+ * @method void set(string $key, PaymentMethodEntity $entity)
  * @method PaymentMethodEntity[] getIterator()
  * @method PaymentMethodEntity[] getElements()
  * @method PaymentMethodEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class PaymentMethodCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return PaymentMethodEntity::class;
     }

--- a/src/Data/Entity/PaymentMethodTranslation/PaymentMethodTranslationCollection.php
+++ b/src/Data/Entity/PaymentMethodTranslation/PaymentMethodTranslationCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\PaymentMethodTranslation;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(PaymentMethodTranslationEntity $entity)
- * @method void set(PaymentMethodTranslationEntity $entity)
+ * @method void set(string $key, PaymentMethodTranslationEntity $entity)
  * @method PaymentMethodTranslationEntity[] getIterator()
  * @method PaymentMethodTranslationEntity[] getElements()
  * @method PaymentMethodTranslationEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class PaymentMethodTranslationCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return PaymentMethodTranslationEntity::class;
     }

--- a/src/Data/Entity/Plugin/PluginCollection.php
+++ b/src/Data/Entity/Plugin/PluginCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\Plugin;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(PluginEntity $entity)
- * @method void set(PluginEntity $entity)
+ * @method void set(string $key, PluginEntity $entity)
  * @method PluginEntity[] getIterator()
  * @method PluginEntity[] getElements()
  * @method PluginEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class PluginCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return PluginEntity::class;
     }

--- a/src/Data/Entity/PluginTranslation/PluginTranslationCollection.php
+++ b/src/Data/Entity/PluginTranslation/PluginTranslationCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\PluginTranslation;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(PluginTranslationEntity $entity)
- * @method void set(PluginTranslationEntity $entity)
+ * @method void set(string $key, PluginTranslationEntity $entity)
  * @method PluginTranslationEntity[] getIterator()
  * @method PluginTranslationEntity[] getElements()
  * @method PluginTranslationEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class PluginTranslationCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return PluginTranslationEntity::class;
     }

--- a/src/Data/Entity/Product/ProductCollection.php
+++ b/src/Data/Entity/Product/ProductCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\Product;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(ProductEntity $entity)
- * @method void set(ProductEntity $entity)
+ * @method void set(string $key, ProductEntity $entity)
  * @method ProductEntity[] getIterator()
  * @method ProductEntity[] getElements()
  * @method ProductEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class ProductCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return ProductEntity::class;
     }

--- a/src/Data/Entity/ProductCategory/ProductCategoryCollection.php
+++ b/src/Data/Entity/ProductCategory/ProductCategoryCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\ProductCategory;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(ProductCategoryEntity $entity)
- * @method void set(ProductCategoryEntity $entity)
+ * @method void set(string $key, ProductCategoryEntity $entity)
  * @method ProductCategoryEntity[] getIterator()
  * @method ProductCategoryEntity[] getElements()
  * @method ProductCategoryEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class ProductCategoryCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return ProductCategoryEntity::class;
     }

--- a/src/Data/Entity/ProductCategoryTree/ProductCategoryTreeCollection.php
+++ b/src/Data/Entity/ProductCategoryTree/ProductCategoryTreeCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\ProductCategoryTree;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(ProductCategoryTreeEntity $entity)
- * @method void set(ProductCategoryTreeEntity $entity)
+ * @method void set(string $key, ProductCategoryTreeEntity $entity)
  * @method ProductCategoryTreeEntity[] getIterator()
  * @method ProductCategoryTreeEntity[] getElements()
  * @method ProductCategoryTreeEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class ProductCategoryTreeCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return ProductCategoryTreeEntity::class;
     }

--- a/src/Data/Entity/ProductConfiguratorSetting/ProductConfiguratorSettingCollection.php
+++ b/src/Data/Entity/ProductConfiguratorSetting/ProductConfiguratorSettingCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\ProductConfiguratorSetting;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(ProductConfiguratorSettingEntity $entity)
- * @method void set(ProductConfiguratorSettingEntity $entity)
+ * @method void set(string $key, ProductConfiguratorSettingEntity $entity)
  * @method ProductConfiguratorSettingEntity[] getIterator()
  * @method ProductConfiguratorSettingEntity[] getElements()
  * @method ProductConfiguratorSettingEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class ProductConfiguratorSettingCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return ProductConfiguratorSettingEntity::class;
     }

--- a/src/Data/Entity/ProductCrossSelling/ProductCrossSellingCollection.php
+++ b/src/Data/Entity/ProductCrossSelling/ProductCrossSellingCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\ProductCrossSelling;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(ProductCrossSellingEntity $entity)
- * @method void set(ProductCrossSellingEntity $entity)
+ * @method void set(string $key, ProductCrossSellingEntity $entity)
  * @method ProductCrossSellingEntity[] getIterator()
  * @method ProductCrossSellingEntity[] getElements()
  * @method ProductCrossSellingEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class ProductCrossSellingCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return ProductCrossSellingEntity::class;
     }

--- a/src/Data/Entity/ProductCrossSellingAssignedProducts/ProductCrossSellingAssignedProductsCollection.php
+++ b/src/Data/Entity/ProductCrossSellingAssignedProducts/ProductCrossSellingAssignedProductsCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\ProductCrossSellingAssignedProducts;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(ProductCrossSellingAssignedProductsEntity $entity)
- * @method void set(ProductCrossSellingAssignedProductsEntity $entity)
+ * @method void set(string $key, ProductCrossSellingAssignedProductsEntity $entity)
  * @method ProductCrossSellingAssignedProductsEntity[] getIterator()
  * @method ProductCrossSellingAssignedProductsEntity[] getElements()
  * @method ProductCrossSellingAssignedProductsEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class ProductCrossSellingAssignedProductsCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return ProductCrossSellingAssignedProductsEntity::class;
     }

--- a/src/Data/Entity/ProductCrossSellingTranslation/ProductCrossSellingTranslationCollection.php
+++ b/src/Data/Entity/ProductCrossSellingTranslation/ProductCrossSellingTranslationCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\ProductCrossSellingTranslation;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(ProductCrossSellingTranslationEntity $entity)
- * @method void set(ProductCrossSellingTranslationEntity $entity)
+ * @method void set(string $key, ProductCrossSellingTranslationEntity $entity)
  * @method ProductCrossSellingTranslationEntity[] getIterator()
  * @method ProductCrossSellingTranslationEntity[] getElements()
  * @method ProductCrossSellingTranslationEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class ProductCrossSellingTranslationCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return ProductCrossSellingTranslationEntity::class;
     }

--- a/src/Data/Entity/ProductCustomFieldSet/ProductCustomFieldSetCollection.php
+++ b/src/Data/Entity/ProductCustomFieldSet/ProductCustomFieldSetCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\ProductCustomFieldSet;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(ProductCustomFieldSetEntity $entity)
- * @method void set(ProductCustomFieldSetEntity $entity)
+ * @method void set(string $key, ProductCustomFieldSetEntity $entity)
  * @method ProductCustomFieldSetEntity[] getIterator()
  * @method ProductCustomFieldSetEntity[] getElements()
  * @method ProductCustomFieldSetEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class ProductCustomFieldSetCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return ProductCustomFieldSetEntity::class;
     }

--- a/src/Data/Entity/ProductDownload/ProductDownloadCollection.php
+++ b/src/Data/Entity/ProductDownload/ProductDownloadCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\ProductDownload;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(ProductDownloadEntity $entity)
- * @method void set(ProductDownloadEntity $entity)
+ * @method void set(string $key, ProductDownloadEntity $entity)
  * @method ProductDownloadEntity[] getIterator()
  * @method ProductDownloadEntity[] getElements()
  * @method ProductDownloadEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class ProductDownloadCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return ProductDownloadEntity::class;
     }

--- a/src/Data/Entity/ProductExport/ProductExportCollection.php
+++ b/src/Data/Entity/ProductExport/ProductExportCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\ProductExport;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(ProductExportEntity $entity)
- * @method void set(ProductExportEntity $entity)
+ * @method void set(string $key, ProductExportEntity $entity)
  * @method ProductExportEntity[] getIterator()
  * @method ProductExportEntity[] getElements()
  * @method ProductExportEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class ProductExportCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return ProductExportEntity::class;
     }

--- a/src/Data/Entity/ProductFeatureSet/ProductFeatureSetCollection.php
+++ b/src/Data/Entity/ProductFeatureSet/ProductFeatureSetCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\ProductFeatureSet;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(ProductFeatureSetEntity $entity)
- * @method void set(ProductFeatureSetEntity $entity)
+ * @method void set(string $key, ProductFeatureSetEntity $entity)
  * @method ProductFeatureSetEntity[] getIterator()
  * @method ProductFeatureSetEntity[] getElements()
  * @method ProductFeatureSetEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class ProductFeatureSetCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return ProductFeatureSetEntity::class;
     }

--- a/src/Data/Entity/ProductFeatureSetTranslation/ProductFeatureSetTranslationCollection.php
+++ b/src/Data/Entity/ProductFeatureSetTranslation/ProductFeatureSetTranslationCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\ProductFeatureSetTranslation;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(ProductFeatureSetTranslationEntity $entity)
- * @method void set(ProductFeatureSetTranslationEntity $entity)
+ * @method void set(string $key, ProductFeatureSetTranslationEntity $entity)
  * @method ProductFeatureSetTranslationEntity[] getIterator()
  * @method ProductFeatureSetTranslationEntity[] getElements()
  * @method ProductFeatureSetTranslationEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class ProductFeatureSetTranslationCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return ProductFeatureSetTranslationEntity::class;
     }

--- a/src/Data/Entity/ProductKeywordDictionary/ProductKeywordDictionaryCollection.php
+++ b/src/Data/Entity/ProductKeywordDictionary/ProductKeywordDictionaryCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\ProductKeywordDictionary;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(ProductKeywordDictionaryEntity $entity)
- * @method void set(ProductKeywordDictionaryEntity $entity)
+ * @method void set(string $key, ProductKeywordDictionaryEntity $entity)
  * @method ProductKeywordDictionaryEntity[] getIterator()
  * @method ProductKeywordDictionaryEntity[] getElements()
  * @method ProductKeywordDictionaryEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class ProductKeywordDictionaryCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return ProductKeywordDictionaryEntity::class;
     }

--- a/src/Data/Entity/ProductManufacturer/ProductManufacturerCollection.php
+++ b/src/Data/Entity/ProductManufacturer/ProductManufacturerCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\ProductManufacturer;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(ProductManufacturerEntity $entity)
- * @method void set(ProductManufacturerEntity $entity)
+ * @method void set(string $key, ProductManufacturerEntity $entity)
  * @method ProductManufacturerEntity[] getIterator()
  * @method ProductManufacturerEntity[] getElements()
  * @method ProductManufacturerEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class ProductManufacturerCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return ProductManufacturerEntity::class;
     }

--- a/src/Data/Entity/ProductManufacturerTranslation/ProductManufacturerTranslationCollection.php
+++ b/src/Data/Entity/ProductManufacturerTranslation/ProductManufacturerTranslationCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\ProductManufacturerTranslation;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(ProductManufacturerTranslationEntity $entity)
- * @method void set(ProductManufacturerTranslationEntity $entity)
+ * @method void set(string $key, ProductManufacturerTranslationEntity $entity)
  * @method ProductManufacturerTranslationEntity[] getIterator()
  * @method ProductManufacturerTranslationEntity[] getElements()
  * @method ProductManufacturerTranslationEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class ProductManufacturerTranslationCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return ProductManufacturerTranslationEntity::class;
     }

--- a/src/Data/Entity/ProductMedia/ProductMediaCollection.php
+++ b/src/Data/Entity/ProductMedia/ProductMediaCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\ProductMedia;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(ProductMediaEntity $entity)
- * @method void set(ProductMediaEntity $entity)
+ * @method void set(string $key, ProductMediaEntity $entity)
  * @method ProductMediaEntity[] getIterator()
  * @method ProductMediaEntity[] getElements()
  * @method ProductMediaEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class ProductMediaCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return ProductMediaEntity::class;
     }

--- a/src/Data/Entity/ProductOption/ProductOptionCollection.php
+++ b/src/Data/Entity/ProductOption/ProductOptionCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\ProductOption;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(ProductOptionEntity $entity)
- * @method void set(ProductOptionEntity $entity)
+ * @method void set(string $key, ProductOptionEntity $entity)
  * @method ProductOptionEntity[] getIterator()
  * @method ProductOptionEntity[] getElements()
  * @method ProductOptionEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class ProductOptionCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return ProductOptionEntity::class;
     }

--- a/src/Data/Entity/ProductPrice/ProductPriceCollection.php
+++ b/src/Data/Entity/ProductPrice/ProductPriceCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\ProductPrice;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(ProductPriceEntity $entity)
- * @method void set(ProductPriceEntity $entity)
+ * @method void set(string $key, ProductPriceEntity $entity)
  * @method ProductPriceEntity[] getIterator()
  * @method ProductPriceEntity[] getElements()
  * @method ProductPriceEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class ProductPriceCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return ProductPriceEntity::class;
     }

--- a/src/Data/Entity/ProductProperty/ProductPropertyCollection.php
+++ b/src/Data/Entity/ProductProperty/ProductPropertyCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\ProductProperty;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(ProductPropertyEntity $entity)
- * @method void set(ProductPropertyEntity $entity)
+ * @method void set(string $key, ProductPropertyEntity $entity)
  * @method ProductPropertyEntity[] getIterator()
  * @method ProductPropertyEntity[] getElements()
  * @method ProductPropertyEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class ProductPropertyCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return ProductPropertyEntity::class;
     }

--- a/src/Data/Entity/ProductReview/ProductReviewCollection.php
+++ b/src/Data/Entity/ProductReview/ProductReviewCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\ProductReview;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(ProductReviewEntity $entity)
- * @method void set(ProductReviewEntity $entity)
+ * @method void set(string $key, ProductReviewEntity $entity)
  * @method ProductReviewEntity[] getIterator()
  * @method ProductReviewEntity[] getElements()
  * @method ProductReviewEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class ProductReviewCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return ProductReviewEntity::class;
     }

--- a/src/Data/Entity/ProductSearchConfig/ProductSearchConfigCollection.php
+++ b/src/Data/Entity/ProductSearchConfig/ProductSearchConfigCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\ProductSearchConfig;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(ProductSearchConfigEntity $entity)
- * @method void set(ProductSearchConfigEntity $entity)
+ * @method void set(string $key, ProductSearchConfigEntity $entity)
  * @method ProductSearchConfigEntity[] getIterator()
  * @method ProductSearchConfigEntity[] getElements()
  * @method ProductSearchConfigEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class ProductSearchConfigCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return ProductSearchConfigEntity::class;
     }

--- a/src/Data/Entity/ProductSearchConfigField/ProductSearchConfigFieldCollection.php
+++ b/src/Data/Entity/ProductSearchConfigField/ProductSearchConfigFieldCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\ProductSearchConfigField;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(ProductSearchConfigFieldEntity $entity)
- * @method void set(ProductSearchConfigFieldEntity $entity)
+ * @method void set(string $key, ProductSearchConfigFieldEntity $entity)
  * @method ProductSearchConfigFieldEntity[] getIterator()
  * @method ProductSearchConfigFieldEntity[] getElements()
  * @method ProductSearchConfigFieldEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class ProductSearchConfigFieldCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return ProductSearchConfigFieldEntity::class;
     }

--- a/src/Data/Entity/ProductSearchKeyword/ProductSearchKeywordCollection.php
+++ b/src/Data/Entity/ProductSearchKeyword/ProductSearchKeywordCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\ProductSearchKeyword;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(ProductSearchKeywordEntity $entity)
- * @method void set(ProductSearchKeywordEntity $entity)
+ * @method void set(string $key, ProductSearchKeywordEntity $entity)
  * @method ProductSearchKeywordEntity[] getIterator()
  * @method ProductSearchKeywordEntity[] getElements()
  * @method ProductSearchKeywordEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class ProductSearchKeywordCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return ProductSearchKeywordEntity::class;
     }

--- a/src/Data/Entity/ProductSorting/ProductSortingCollection.php
+++ b/src/Data/Entity/ProductSorting/ProductSortingCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\ProductSorting;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(ProductSortingEntity $entity)
- * @method void set(ProductSortingEntity $entity)
+ * @method void set(string $key, ProductSortingEntity $entity)
  * @method ProductSortingEntity[] getIterator()
  * @method ProductSortingEntity[] getElements()
  * @method ProductSortingEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class ProductSortingCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return ProductSortingEntity::class;
     }

--- a/src/Data/Entity/ProductSortingTranslation/ProductSortingTranslationCollection.php
+++ b/src/Data/Entity/ProductSortingTranslation/ProductSortingTranslationCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\ProductSortingTranslation;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(ProductSortingTranslationEntity $entity)
- * @method void set(ProductSortingTranslationEntity $entity)
+ * @method void set(string $key, ProductSortingTranslationEntity $entity)
  * @method ProductSortingTranslationEntity[] getIterator()
  * @method ProductSortingTranslationEntity[] getElements()
  * @method ProductSortingTranslationEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class ProductSortingTranslationCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return ProductSortingTranslationEntity::class;
     }

--- a/src/Data/Entity/ProductStream/ProductStreamCollection.php
+++ b/src/Data/Entity/ProductStream/ProductStreamCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\ProductStream;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(ProductStreamEntity $entity)
- * @method void set(ProductStreamEntity $entity)
+ * @method void set(string $key, ProductStreamEntity $entity)
  * @method ProductStreamEntity[] getIterator()
  * @method ProductStreamEntity[] getElements()
  * @method ProductStreamEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class ProductStreamCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return ProductStreamEntity::class;
     }

--- a/src/Data/Entity/ProductStreamFilter/ProductStreamFilterCollection.php
+++ b/src/Data/Entity/ProductStreamFilter/ProductStreamFilterCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\ProductStreamFilter;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(ProductStreamFilterEntity $entity)
- * @method void set(ProductStreamFilterEntity $entity)
+ * @method void set(string $key, ProductStreamFilterEntity $entity)
  * @method ProductStreamFilterEntity[] getIterator()
  * @method ProductStreamFilterEntity[] getElements()
  * @method ProductStreamFilterEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class ProductStreamFilterCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return ProductStreamFilterEntity::class;
     }

--- a/src/Data/Entity/ProductStreamMapping/ProductStreamMappingCollection.php
+++ b/src/Data/Entity/ProductStreamMapping/ProductStreamMappingCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\ProductStreamMapping;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(ProductStreamMappingEntity $entity)
- * @method void set(ProductStreamMappingEntity $entity)
+ * @method void set(string $key, ProductStreamMappingEntity $entity)
  * @method ProductStreamMappingEntity[] getIterator()
  * @method ProductStreamMappingEntity[] getElements()
  * @method ProductStreamMappingEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class ProductStreamMappingCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return ProductStreamMappingEntity::class;
     }

--- a/src/Data/Entity/ProductStreamTranslation/ProductStreamTranslationCollection.php
+++ b/src/Data/Entity/ProductStreamTranslation/ProductStreamTranslationCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\ProductStreamTranslation;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(ProductStreamTranslationEntity $entity)
- * @method void set(ProductStreamTranslationEntity $entity)
+ * @method void set(string $key, ProductStreamTranslationEntity $entity)
  * @method ProductStreamTranslationEntity[] getIterator()
  * @method ProductStreamTranslationEntity[] getElements()
  * @method ProductStreamTranslationEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class ProductStreamTranslationCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return ProductStreamTranslationEntity::class;
     }

--- a/src/Data/Entity/ProductTag/ProductTagCollection.php
+++ b/src/Data/Entity/ProductTag/ProductTagCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\ProductTag;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(ProductTagEntity $entity)
- * @method void set(ProductTagEntity $entity)
+ * @method void set(string $key, ProductTagEntity $entity)
  * @method ProductTagEntity[] getIterator()
  * @method ProductTagEntity[] getElements()
  * @method ProductTagEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class ProductTagCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return ProductTagEntity::class;
     }

--- a/src/Data/Entity/ProductTranslation/ProductTranslationCollection.php
+++ b/src/Data/Entity/ProductTranslation/ProductTranslationCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\ProductTranslation;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(ProductTranslationEntity $entity)
- * @method void set(ProductTranslationEntity $entity)
+ * @method void set(string $key, ProductTranslationEntity $entity)
  * @method ProductTranslationEntity[] getIterator()
  * @method ProductTranslationEntity[] getElements()
  * @method ProductTranslationEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class ProductTranslationCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return ProductTranslationEntity::class;
     }

--- a/src/Data/Entity/ProductVisibility/ProductVisibilityCollection.php
+++ b/src/Data/Entity/ProductVisibility/ProductVisibilityCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\ProductVisibility;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(ProductVisibilityEntity $entity)
- * @method void set(ProductVisibilityEntity $entity)
+ * @method void set(string $key, ProductVisibilityEntity $entity)
  * @method ProductVisibilityEntity[] getIterator()
  * @method ProductVisibilityEntity[] getElements()
  * @method ProductVisibilityEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class ProductVisibilityCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return ProductVisibilityEntity::class;
     }

--- a/src/Data/Entity/Promotion/PromotionCollection.php
+++ b/src/Data/Entity/Promotion/PromotionCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\Promotion;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(PromotionEntity $entity)
- * @method void set(PromotionEntity $entity)
+ * @method void set(string $key, PromotionEntity $entity)
  * @method PromotionEntity[] getIterator()
  * @method PromotionEntity[] getElements()
  * @method PromotionEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class PromotionCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return PromotionEntity::class;
     }

--- a/src/Data/Entity/PromotionCartRule/PromotionCartRuleCollection.php
+++ b/src/Data/Entity/PromotionCartRule/PromotionCartRuleCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\PromotionCartRule;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(PromotionCartRuleEntity $entity)
- * @method void set(PromotionCartRuleEntity $entity)
+ * @method void set(string $key, PromotionCartRuleEntity $entity)
  * @method PromotionCartRuleEntity[] getIterator()
  * @method PromotionCartRuleEntity[] getElements()
  * @method PromotionCartRuleEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class PromotionCartRuleCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return PromotionCartRuleEntity::class;
     }

--- a/src/Data/Entity/PromotionDiscount/PromotionDiscountCollection.php
+++ b/src/Data/Entity/PromotionDiscount/PromotionDiscountCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\PromotionDiscount;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(PromotionDiscountEntity $entity)
- * @method void set(PromotionDiscountEntity $entity)
+ * @method void set(string $key, PromotionDiscountEntity $entity)
  * @method PromotionDiscountEntity[] getIterator()
  * @method PromotionDiscountEntity[] getElements()
  * @method PromotionDiscountEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class PromotionDiscountCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return PromotionDiscountEntity::class;
     }

--- a/src/Data/Entity/PromotionDiscountPrices/PromotionDiscountPricesCollection.php
+++ b/src/Data/Entity/PromotionDiscountPrices/PromotionDiscountPricesCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\PromotionDiscountPrices;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(PromotionDiscountPricesEntity $entity)
- * @method void set(PromotionDiscountPricesEntity $entity)
+ * @method void set(string $key, PromotionDiscountPricesEntity $entity)
  * @method PromotionDiscountPricesEntity[] getIterator()
  * @method PromotionDiscountPricesEntity[] getElements()
  * @method PromotionDiscountPricesEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class PromotionDiscountPricesCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return PromotionDiscountPricesEntity::class;
     }

--- a/src/Data/Entity/PromotionDiscountRule/PromotionDiscountRuleCollection.php
+++ b/src/Data/Entity/PromotionDiscountRule/PromotionDiscountRuleCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\PromotionDiscountRule;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(PromotionDiscountRuleEntity $entity)
- * @method void set(PromotionDiscountRuleEntity $entity)
+ * @method void set(string $key, PromotionDiscountRuleEntity $entity)
  * @method PromotionDiscountRuleEntity[] getIterator()
  * @method PromotionDiscountRuleEntity[] getElements()
  * @method PromotionDiscountRuleEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class PromotionDiscountRuleCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return PromotionDiscountRuleEntity::class;
     }

--- a/src/Data/Entity/PromotionIndividualCode/PromotionIndividualCodeCollection.php
+++ b/src/Data/Entity/PromotionIndividualCode/PromotionIndividualCodeCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\PromotionIndividualCode;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(PromotionIndividualCodeEntity $entity)
- * @method void set(PromotionIndividualCodeEntity $entity)
+ * @method void set(string $key, PromotionIndividualCodeEntity $entity)
  * @method PromotionIndividualCodeEntity[] getIterator()
  * @method PromotionIndividualCodeEntity[] getElements()
  * @method PromotionIndividualCodeEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class PromotionIndividualCodeCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return PromotionIndividualCodeEntity::class;
     }

--- a/src/Data/Entity/PromotionOrderRule/PromotionOrderRuleCollection.php
+++ b/src/Data/Entity/PromotionOrderRule/PromotionOrderRuleCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\PromotionOrderRule;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(PromotionOrderRuleEntity $entity)
- * @method void set(PromotionOrderRuleEntity $entity)
+ * @method void set(string $key, PromotionOrderRuleEntity $entity)
  * @method PromotionOrderRuleEntity[] getIterator()
  * @method PromotionOrderRuleEntity[] getElements()
  * @method PromotionOrderRuleEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class PromotionOrderRuleCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return PromotionOrderRuleEntity::class;
     }

--- a/src/Data/Entity/PromotionPersonaCustomer/PromotionPersonaCustomerCollection.php
+++ b/src/Data/Entity/PromotionPersonaCustomer/PromotionPersonaCustomerCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\PromotionPersonaCustomer;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(PromotionPersonaCustomerEntity $entity)
- * @method void set(PromotionPersonaCustomerEntity $entity)
+ * @method void set(string $key, PromotionPersonaCustomerEntity $entity)
  * @method PromotionPersonaCustomerEntity[] getIterator()
  * @method PromotionPersonaCustomerEntity[] getElements()
  * @method PromotionPersonaCustomerEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class PromotionPersonaCustomerCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return PromotionPersonaCustomerEntity::class;
     }

--- a/src/Data/Entity/PromotionPersonaRule/PromotionPersonaRuleCollection.php
+++ b/src/Data/Entity/PromotionPersonaRule/PromotionPersonaRuleCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\PromotionPersonaRule;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(PromotionPersonaRuleEntity $entity)
- * @method void set(PromotionPersonaRuleEntity $entity)
+ * @method void set(string $key, PromotionPersonaRuleEntity $entity)
  * @method PromotionPersonaRuleEntity[] getIterator()
  * @method PromotionPersonaRuleEntity[] getElements()
  * @method PromotionPersonaRuleEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class PromotionPersonaRuleCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return PromotionPersonaRuleEntity::class;
     }

--- a/src/Data/Entity/PromotionSalesChannel/PromotionSalesChannelCollection.php
+++ b/src/Data/Entity/PromotionSalesChannel/PromotionSalesChannelCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\PromotionSalesChannel;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(PromotionSalesChannelEntity $entity)
- * @method void set(PromotionSalesChannelEntity $entity)
+ * @method void set(string $key, PromotionSalesChannelEntity $entity)
  * @method PromotionSalesChannelEntity[] getIterator()
  * @method PromotionSalesChannelEntity[] getElements()
  * @method PromotionSalesChannelEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class PromotionSalesChannelCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return PromotionSalesChannelEntity::class;
     }

--- a/src/Data/Entity/PromotionSetgroup/PromotionSetgroupCollection.php
+++ b/src/Data/Entity/PromotionSetgroup/PromotionSetgroupCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\PromotionSetgroup;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(PromotionSetgroupEntity $entity)
- * @method void set(PromotionSetgroupEntity $entity)
+ * @method void set(string $key, PromotionSetgroupEntity $entity)
  * @method PromotionSetgroupEntity[] getIterator()
  * @method PromotionSetgroupEntity[] getElements()
  * @method PromotionSetgroupEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class PromotionSetgroupCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return PromotionSetgroupEntity::class;
     }

--- a/src/Data/Entity/PromotionSetgroupRule/PromotionSetgroupRuleCollection.php
+++ b/src/Data/Entity/PromotionSetgroupRule/PromotionSetgroupRuleCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\PromotionSetgroupRule;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(PromotionSetgroupRuleEntity $entity)
- * @method void set(PromotionSetgroupRuleEntity $entity)
+ * @method void set(string $key, PromotionSetgroupRuleEntity $entity)
  * @method PromotionSetgroupRuleEntity[] getIterator()
  * @method PromotionSetgroupRuleEntity[] getElements()
  * @method PromotionSetgroupRuleEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class PromotionSetgroupRuleCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return PromotionSetgroupRuleEntity::class;
     }

--- a/src/Data/Entity/PromotionTranslation/PromotionTranslationCollection.php
+++ b/src/Data/Entity/PromotionTranslation/PromotionTranslationCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\PromotionTranslation;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(PromotionTranslationEntity $entity)
- * @method void set(PromotionTranslationEntity $entity)
+ * @method void set(string $key, PromotionTranslationEntity $entity)
  * @method PromotionTranslationEntity[] getIterator()
  * @method PromotionTranslationEntity[] getElements()
  * @method PromotionTranslationEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class PromotionTranslationCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return PromotionTranslationEntity::class;
     }

--- a/src/Data/Entity/PropertyGroup/PropertyGroupCollection.php
+++ b/src/Data/Entity/PropertyGroup/PropertyGroupCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\PropertyGroup;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(PropertyGroupEntity $entity)
- * @method void set(PropertyGroupEntity $entity)
+ * @method void set(string $key, PropertyGroupEntity $entity)
  * @method PropertyGroupEntity[] getIterator()
  * @method PropertyGroupEntity[] getElements()
  * @method PropertyGroupEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class PropertyGroupCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return PropertyGroupEntity::class;
     }

--- a/src/Data/Entity/PropertyGroupOption/PropertyGroupOptionCollection.php
+++ b/src/Data/Entity/PropertyGroupOption/PropertyGroupOptionCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\PropertyGroupOption;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(PropertyGroupOptionEntity $entity)
- * @method void set(PropertyGroupOptionEntity $entity)
+ * @method void set(string $key, PropertyGroupOptionEntity $entity)
  * @method PropertyGroupOptionEntity[] getIterator()
  * @method PropertyGroupOptionEntity[] getElements()
  * @method PropertyGroupOptionEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class PropertyGroupOptionCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return PropertyGroupOptionEntity::class;
     }

--- a/src/Data/Entity/PropertyGroupOptionTranslation/PropertyGroupOptionTranslationCollection.php
+++ b/src/Data/Entity/PropertyGroupOptionTranslation/PropertyGroupOptionTranslationCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\PropertyGroupOptionTranslation;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(PropertyGroupOptionTranslationEntity $entity)
- * @method void set(PropertyGroupOptionTranslationEntity $entity)
+ * @method void set(string $key, PropertyGroupOptionTranslationEntity $entity)
  * @method PropertyGroupOptionTranslationEntity[] getIterator()
  * @method PropertyGroupOptionTranslationEntity[] getElements()
  * @method PropertyGroupOptionTranslationEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class PropertyGroupOptionTranslationCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return PropertyGroupOptionTranslationEntity::class;
     }

--- a/src/Data/Entity/PropertyGroupTranslation/PropertyGroupTranslationCollection.php
+++ b/src/Data/Entity/PropertyGroupTranslation/PropertyGroupTranslationCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\PropertyGroupTranslation;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(PropertyGroupTranslationEntity $entity)
- * @method void set(PropertyGroupTranslationEntity $entity)
+ * @method void set(string $key, PropertyGroupTranslationEntity $entity)
  * @method PropertyGroupTranslationEntity[] getIterator()
  * @method PropertyGroupTranslationEntity[] getElements()
  * @method PropertyGroupTranslationEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class PropertyGroupTranslationCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return PropertyGroupTranslationEntity::class;
     }

--- a/src/Data/Entity/Rule/RuleCollection.php
+++ b/src/Data/Entity/Rule/RuleCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\Rule;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(RuleEntity $entity)
- * @method void set(RuleEntity $entity)
+ * @method void set(string $key, RuleEntity $entity)
  * @method RuleEntity[] getIterator()
  * @method RuleEntity[] getElements()
  * @method RuleEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class RuleCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return RuleEntity::class;
     }

--- a/src/Data/Entity/RuleCondition/RuleConditionCollection.php
+++ b/src/Data/Entity/RuleCondition/RuleConditionCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\RuleCondition;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(RuleConditionEntity $entity)
- * @method void set(RuleConditionEntity $entity)
+ * @method void set(string $key, RuleConditionEntity $entity)
  * @method RuleConditionEntity[] getIterator()
  * @method RuleConditionEntity[] getElements()
  * @method RuleConditionEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class RuleConditionCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return RuleConditionEntity::class;
     }

--- a/src/Data/Entity/RuleTag/RuleTagCollection.php
+++ b/src/Data/Entity/RuleTag/RuleTagCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\RuleTag;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(RuleTagEntity $entity)
- * @method void set(RuleTagEntity $entity)
+ * @method void set(string $key, RuleTagEntity $entity)
  * @method RuleTagEntity[] getIterator()
  * @method RuleTagEntity[] getElements()
  * @method RuleTagEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class RuleTagCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return RuleTagEntity::class;
     }

--- a/src/Data/Entity/SalesChannel/SalesChannelCollection.php
+++ b/src/Data/Entity/SalesChannel/SalesChannelCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\SalesChannel;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(SalesChannelEntity $entity)
- * @method void set(SalesChannelEntity $entity)
+ * @method void set(string $key, SalesChannelEntity $entity)
  * @method SalesChannelEntity[] getIterator()
  * @method SalesChannelEntity[] getElements()
  * @method SalesChannelEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class SalesChannelCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return SalesChannelEntity::class;
     }

--- a/src/Data/Entity/SalesChannelAnalytics/SalesChannelAnalyticsCollection.php
+++ b/src/Data/Entity/SalesChannelAnalytics/SalesChannelAnalyticsCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\SalesChannelAnalytics;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(SalesChannelAnalyticsEntity $entity)
- * @method void set(SalesChannelAnalyticsEntity $entity)
+ * @method void set(string $key, SalesChannelAnalyticsEntity $entity)
  * @method SalesChannelAnalyticsEntity[] getIterator()
  * @method SalesChannelAnalyticsEntity[] getElements()
  * @method SalesChannelAnalyticsEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class SalesChannelAnalyticsCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return SalesChannelAnalyticsEntity::class;
     }

--- a/src/Data/Entity/SalesChannelCountry/SalesChannelCountryCollection.php
+++ b/src/Data/Entity/SalesChannelCountry/SalesChannelCountryCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\SalesChannelCountry;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(SalesChannelCountryEntity $entity)
- * @method void set(SalesChannelCountryEntity $entity)
+ * @method void set(string $key, SalesChannelCountryEntity $entity)
  * @method SalesChannelCountryEntity[] getIterator()
  * @method SalesChannelCountryEntity[] getElements()
  * @method SalesChannelCountryEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class SalesChannelCountryCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return SalesChannelCountryEntity::class;
     }

--- a/src/Data/Entity/SalesChannelCurrency/SalesChannelCurrencyCollection.php
+++ b/src/Data/Entity/SalesChannelCurrency/SalesChannelCurrencyCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\SalesChannelCurrency;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(SalesChannelCurrencyEntity $entity)
- * @method void set(SalesChannelCurrencyEntity $entity)
+ * @method void set(string $key, SalesChannelCurrencyEntity $entity)
  * @method SalesChannelCurrencyEntity[] getIterator()
  * @method SalesChannelCurrencyEntity[] getElements()
  * @method SalesChannelCurrencyEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class SalesChannelCurrencyCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return SalesChannelCurrencyEntity::class;
     }

--- a/src/Data/Entity/SalesChannelDomain/SalesChannelDomainCollection.php
+++ b/src/Data/Entity/SalesChannelDomain/SalesChannelDomainCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\SalesChannelDomain;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(SalesChannelDomainEntity $entity)
- * @method void set(SalesChannelDomainEntity $entity)
+ * @method void set(string $key, SalesChannelDomainEntity $entity)
  * @method SalesChannelDomainEntity[] getIterator()
  * @method SalesChannelDomainEntity[] getElements()
  * @method SalesChannelDomainEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class SalesChannelDomainCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return SalesChannelDomainEntity::class;
     }

--- a/src/Data/Entity/SalesChannelLanguage/SalesChannelLanguageCollection.php
+++ b/src/Data/Entity/SalesChannelLanguage/SalesChannelLanguageCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\SalesChannelLanguage;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(SalesChannelLanguageEntity $entity)
- * @method void set(SalesChannelLanguageEntity $entity)
+ * @method void set(string $key, SalesChannelLanguageEntity $entity)
  * @method SalesChannelLanguageEntity[] getIterator()
  * @method SalesChannelLanguageEntity[] getElements()
  * @method SalesChannelLanguageEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class SalesChannelLanguageCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return SalesChannelLanguageEntity::class;
     }

--- a/src/Data/Entity/SalesChannelPaymentMethod/SalesChannelPaymentMethodCollection.php
+++ b/src/Data/Entity/SalesChannelPaymentMethod/SalesChannelPaymentMethodCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\SalesChannelPaymentMethod;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(SalesChannelPaymentMethodEntity $entity)
- * @method void set(SalesChannelPaymentMethodEntity $entity)
+ * @method void set(string $key, SalesChannelPaymentMethodEntity $entity)
  * @method SalesChannelPaymentMethodEntity[] getIterator()
  * @method SalesChannelPaymentMethodEntity[] getElements()
  * @method SalesChannelPaymentMethodEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class SalesChannelPaymentMethodCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return SalesChannelPaymentMethodEntity::class;
     }

--- a/src/Data/Entity/SalesChannelShippingMethod/SalesChannelShippingMethodCollection.php
+++ b/src/Data/Entity/SalesChannelShippingMethod/SalesChannelShippingMethodCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\SalesChannelShippingMethod;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(SalesChannelShippingMethodEntity $entity)
- * @method void set(SalesChannelShippingMethodEntity $entity)
+ * @method void set(string $key, SalesChannelShippingMethodEntity $entity)
  * @method SalesChannelShippingMethodEntity[] getIterator()
  * @method SalesChannelShippingMethodEntity[] getElements()
  * @method SalesChannelShippingMethodEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class SalesChannelShippingMethodCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return SalesChannelShippingMethodEntity::class;
     }

--- a/src/Data/Entity/SalesChannelTranslation/SalesChannelTranslationCollection.php
+++ b/src/Data/Entity/SalesChannelTranslation/SalesChannelTranslationCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\SalesChannelTranslation;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(SalesChannelTranslationEntity $entity)
- * @method void set(SalesChannelTranslationEntity $entity)
+ * @method void set(string $key, SalesChannelTranslationEntity $entity)
  * @method SalesChannelTranslationEntity[] getIterator()
  * @method SalesChannelTranslationEntity[] getElements()
  * @method SalesChannelTranslationEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class SalesChannelTranslationCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return SalesChannelTranslationEntity::class;
     }

--- a/src/Data/Entity/SalesChannelType/SalesChannelTypeCollection.php
+++ b/src/Data/Entity/SalesChannelType/SalesChannelTypeCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\SalesChannelType;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(SalesChannelTypeEntity $entity)
- * @method void set(SalesChannelTypeEntity $entity)
+ * @method void set(string $key, SalesChannelTypeEntity $entity)
  * @method SalesChannelTypeEntity[] getIterator()
  * @method SalesChannelTypeEntity[] getElements()
  * @method SalesChannelTypeEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class SalesChannelTypeCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return SalesChannelTypeEntity::class;
     }

--- a/src/Data/Entity/SalesChannelTypeTranslation/SalesChannelTypeTranslationCollection.php
+++ b/src/Data/Entity/SalesChannelTypeTranslation/SalesChannelTypeTranslationCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\SalesChannelTypeTranslation;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(SalesChannelTypeTranslationEntity $entity)
- * @method void set(SalesChannelTypeTranslationEntity $entity)
+ * @method void set(string $key, SalesChannelTypeTranslationEntity $entity)
  * @method SalesChannelTypeTranslationEntity[] getIterator()
  * @method SalesChannelTypeTranslationEntity[] getElements()
  * @method SalesChannelTypeTranslationEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class SalesChannelTypeTranslationCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return SalesChannelTypeTranslationEntity::class;
     }

--- a/src/Data/Entity/Salutation/SalutationCollection.php
+++ b/src/Data/Entity/Salutation/SalutationCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\Salutation;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(SalutationEntity $entity)
- * @method void set(SalutationEntity $entity)
+ * @method void set(string $key, SalutationEntity $entity)
  * @method SalutationEntity[] getIterator()
  * @method SalutationEntity[] getElements()
  * @method SalutationEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class SalutationCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return SalutationEntity::class;
     }

--- a/src/Data/Entity/SalutationTranslation/SalutationTranslationCollection.php
+++ b/src/Data/Entity/SalutationTranslation/SalutationTranslationCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\SalutationTranslation;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(SalutationTranslationEntity $entity)
- * @method void set(SalutationTranslationEntity $entity)
+ * @method void set(string $key, SalutationTranslationEntity $entity)
  * @method SalutationTranslationEntity[] getIterator()
  * @method SalutationTranslationEntity[] getElements()
  * @method SalutationTranslationEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class SalutationTranslationCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return SalutationTranslationEntity::class;
     }

--- a/src/Data/Entity/ScheduledTask/ScheduledTaskCollection.php
+++ b/src/Data/Entity/ScheduledTask/ScheduledTaskCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\ScheduledTask;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(ScheduledTaskEntity $entity)
- * @method void set(ScheduledTaskEntity $entity)
+ * @method void set(string $key, ScheduledTaskEntity $entity)
  * @method ScheduledTaskEntity[] getIterator()
  * @method ScheduledTaskEntity[] getElements()
  * @method ScheduledTaskEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class ScheduledTaskCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return ScheduledTaskEntity::class;
     }

--- a/src/Data/Entity/Script/ScriptCollection.php
+++ b/src/Data/Entity/Script/ScriptCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\Script;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(ScriptEntity $entity)
- * @method void set(ScriptEntity $entity)
+ * @method void set(string $key, ScriptEntity $entity)
  * @method ScriptEntity[] getIterator()
  * @method ScriptEntity[] getElements()
  * @method ScriptEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class ScriptCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return ScriptEntity::class;
     }

--- a/src/Data/Entity/SeoUrl/SeoUrlCollection.php
+++ b/src/Data/Entity/SeoUrl/SeoUrlCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\SeoUrl;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(SeoUrlEntity $entity)
- * @method void set(SeoUrlEntity $entity)
+ * @method void set(string $key, SeoUrlEntity $entity)
  * @method SeoUrlEntity[] getIterator()
  * @method SeoUrlEntity[] getElements()
  * @method SeoUrlEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class SeoUrlCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return SeoUrlEntity::class;
     }

--- a/src/Data/Entity/SeoUrlTemplate/SeoUrlTemplateCollection.php
+++ b/src/Data/Entity/SeoUrlTemplate/SeoUrlTemplateCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\SeoUrlTemplate;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(SeoUrlTemplateEntity $entity)
- * @method void set(SeoUrlTemplateEntity $entity)
+ * @method void set(string $key, SeoUrlTemplateEntity $entity)
  * @method SeoUrlTemplateEntity[] getIterator()
  * @method SeoUrlTemplateEntity[] getElements()
  * @method SeoUrlTemplateEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class SeoUrlTemplateCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return SeoUrlTemplateEntity::class;
     }

--- a/src/Data/Entity/ShippingMethod/ShippingMethodCollection.php
+++ b/src/Data/Entity/ShippingMethod/ShippingMethodCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\ShippingMethod;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(ShippingMethodEntity $entity)
- * @method void set(ShippingMethodEntity $entity)
+ * @method void set(string $key, ShippingMethodEntity $entity)
  * @method ShippingMethodEntity[] getIterator()
  * @method ShippingMethodEntity[] getElements()
  * @method ShippingMethodEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class ShippingMethodCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return ShippingMethodEntity::class;
     }

--- a/src/Data/Entity/ShippingMethodPrice/ShippingMethodPriceCollection.php
+++ b/src/Data/Entity/ShippingMethodPrice/ShippingMethodPriceCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\ShippingMethodPrice;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(ShippingMethodPriceEntity $entity)
- * @method void set(ShippingMethodPriceEntity $entity)
+ * @method void set(string $key, ShippingMethodPriceEntity $entity)
  * @method ShippingMethodPriceEntity[] getIterator()
  * @method ShippingMethodPriceEntity[] getElements()
  * @method ShippingMethodPriceEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class ShippingMethodPriceCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return ShippingMethodPriceEntity::class;
     }

--- a/src/Data/Entity/ShippingMethodTag/ShippingMethodTagCollection.php
+++ b/src/Data/Entity/ShippingMethodTag/ShippingMethodTagCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\ShippingMethodTag;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(ShippingMethodTagEntity $entity)
- * @method void set(ShippingMethodTagEntity $entity)
+ * @method void set(string $key, ShippingMethodTagEntity $entity)
  * @method ShippingMethodTagEntity[] getIterator()
  * @method ShippingMethodTagEntity[] getElements()
  * @method ShippingMethodTagEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class ShippingMethodTagCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return ShippingMethodTagEntity::class;
     }

--- a/src/Data/Entity/ShippingMethodTranslation/ShippingMethodTranslationCollection.php
+++ b/src/Data/Entity/ShippingMethodTranslation/ShippingMethodTranslationCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\ShippingMethodTranslation;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(ShippingMethodTranslationEntity $entity)
- * @method void set(ShippingMethodTranslationEntity $entity)
+ * @method void set(string $key, ShippingMethodTranslationEntity $entity)
  * @method ShippingMethodTranslationEntity[] getIterator()
  * @method ShippingMethodTranslationEntity[] getElements()
  * @method ShippingMethodTranslationEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class ShippingMethodTranslationCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return ShippingMethodTranslationEntity::class;
     }

--- a/src/Data/Entity/Snippet/SnippetCollection.php
+++ b/src/Data/Entity/Snippet/SnippetCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\Snippet;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(SnippetEntity $entity)
- * @method void set(SnippetEntity $entity)
+ * @method void set(string $key, SnippetEntity $entity)
  * @method SnippetEntity[] getIterator()
  * @method SnippetEntity[] getElements()
  * @method SnippetEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class SnippetCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return SnippetEntity::class;
     }

--- a/src/Data/Entity/SnippetSet/SnippetSetCollection.php
+++ b/src/Data/Entity/SnippetSet/SnippetSetCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\SnippetSet;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(SnippetSetEntity $entity)
- * @method void set(SnippetSetEntity $entity)
+ * @method void set(string $key, SnippetSetEntity $entity)
  * @method SnippetSetEntity[] getIterator()
  * @method SnippetSetEntity[] getElements()
  * @method SnippetSetEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class SnippetSetCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return SnippetSetEntity::class;
     }

--- a/src/Data/Entity/StateMachine/StateMachineCollection.php
+++ b/src/Data/Entity/StateMachine/StateMachineCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\StateMachine;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(StateMachineEntity $entity)
- * @method void set(StateMachineEntity $entity)
+ * @method void set(string $key, StateMachineEntity $entity)
  * @method StateMachineEntity[] getIterator()
  * @method StateMachineEntity[] getElements()
  * @method StateMachineEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class StateMachineCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return StateMachineEntity::class;
     }

--- a/src/Data/Entity/StateMachineHistory/StateMachineHistoryCollection.php
+++ b/src/Data/Entity/StateMachineHistory/StateMachineHistoryCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\StateMachineHistory;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(StateMachineHistoryEntity $entity)
- * @method void set(StateMachineHistoryEntity $entity)
+ * @method void set(string $key, StateMachineHistoryEntity $entity)
  * @method StateMachineHistoryEntity[] getIterator()
  * @method StateMachineHistoryEntity[] getElements()
  * @method StateMachineHistoryEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class StateMachineHistoryCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return StateMachineHistoryEntity::class;
     }

--- a/src/Data/Entity/StateMachineState/StateMachineStateCollection.php
+++ b/src/Data/Entity/StateMachineState/StateMachineStateCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\StateMachineState;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(StateMachineStateEntity $entity)
- * @method void set(StateMachineStateEntity $entity)
+ * @method void set(string $key, StateMachineStateEntity $entity)
  * @method StateMachineStateEntity[] getIterator()
  * @method StateMachineStateEntity[] getElements()
  * @method StateMachineStateEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class StateMachineStateCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return StateMachineStateEntity::class;
     }

--- a/src/Data/Entity/StateMachineStateTranslation/StateMachineStateTranslationCollection.php
+++ b/src/Data/Entity/StateMachineStateTranslation/StateMachineStateTranslationCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\StateMachineStateTranslation;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(StateMachineStateTranslationEntity $entity)
- * @method void set(StateMachineStateTranslationEntity $entity)
+ * @method void set(string $key, StateMachineStateTranslationEntity $entity)
  * @method StateMachineStateTranslationEntity[] getIterator()
  * @method StateMachineStateTranslationEntity[] getElements()
  * @method StateMachineStateTranslationEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class StateMachineStateTranslationCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return StateMachineStateTranslationEntity::class;
     }

--- a/src/Data/Entity/StateMachineTransition/StateMachineTransitionCollection.php
+++ b/src/Data/Entity/StateMachineTransition/StateMachineTransitionCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\StateMachineTransition;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(StateMachineTransitionEntity $entity)
- * @method void set(StateMachineTransitionEntity $entity)
+ * @method void set(string $key, StateMachineTransitionEntity $entity)
  * @method StateMachineTransitionEntity[] getIterator()
  * @method StateMachineTransitionEntity[] getElements()
  * @method StateMachineTransitionEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class StateMachineTransitionCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return StateMachineTransitionEntity::class;
     }

--- a/src/Data/Entity/StateMachineTranslation/StateMachineTranslationCollection.php
+++ b/src/Data/Entity/StateMachineTranslation/StateMachineTranslationCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\StateMachineTranslation;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(StateMachineTranslationEntity $entity)
- * @method void set(StateMachineTranslationEntity $entity)
+ * @method void set(string $key, StateMachineTranslationEntity $entity)
  * @method StateMachineTranslationEntity[] getIterator()
  * @method StateMachineTranslationEntity[] getElements()
  * @method StateMachineTranslationEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class StateMachineTranslationCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return StateMachineTranslationEntity::class;
     }

--- a/src/Data/Entity/SystemConfig/SystemConfigCollection.php
+++ b/src/Data/Entity/SystemConfig/SystemConfigCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\SystemConfig;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(SystemConfigEntity $entity)
- * @method void set(SystemConfigEntity $entity)
+ * @method void set(string $key, SystemConfigEntity $entity)
  * @method SystemConfigEntity[] getIterator()
  * @method SystemConfigEntity[] getElements()
  * @method SystemConfigEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class SystemConfigCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return SystemConfigEntity::class;
     }

--- a/src/Data/Entity/Tag/TagCollection.php
+++ b/src/Data/Entity/Tag/TagCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\Tag;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(TagEntity $entity)
- * @method void set(TagEntity $entity)
+ * @method void set(string $key, TagEntity $entity)
  * @method TagEntity[] getIterator()
  * @method TagEntity[] getElements()
  * @method TagEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class TagCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return TagEntity::class;
     }

--- a/src/Data/Entity/Tax/TaxCollection.php
+++ b/src/Data/Entity/Tax/TaxCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\Tax;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(TaxEntity $entity)
- * @method void set(TaxEntity $entity)
+ * @method void set(string $key, TaxEntity $entity)
  * @method TaxEntity[] getIterator()
  * @method TaxEntity[] getElements()
  * @method TaxEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class TaxCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return TaxEntity::class;
     }

--- a/src/Data/Entity/TaxProvider/TaxProviderCollection.php
+++ b/src/Data/Entity/TaxProvider/TaxProviderCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\TaxProvider;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(TaxProviderEntity $entity)
- * @method void set(TaxProviderEntity $entity)
+ * @method void set(string $key, TaxProviderEntity $entity)
  * @method TaxProviderEntity[] getIterator()
  * @method TaxProviderEntity[] getElements()
  * @method TaxProviderEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class TaxProviderCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return TaxProviderEntity::class;
     }

--- a/src/Data/Entity/TaxProviderTranslation/TaxProviderTranslationCollection.php
+++ b/src/Data/Entity/TaxProviderTranslation/TaxProviderTranslationCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\TaxProviderTranslation;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(TaxProviderTranslationEntity $entity)
- * @method void set(TaxProviderTranslationEntity $entity)
+ * @method void set(string $key, TaxProviderTranslationEntity $entity)
  * @method TaxProviderTranslationEntity[] getIterator()
  * @method TaxProviderTranslationEntity[] getElements()
  * @method TaxProviderTranslationEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class TaxProviderTranslationCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return TaxProviderTranslationEntity::class;
     }

--- a/src/Data/Entity/TaxRule/TaxRuleCollection.php
+++ b/src/Data/Entity/TaxRule/TaxRuleCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\TaxRule;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(TaxRuleEntity $entity)
- * @method void set(TaxRuleEntity $entity)
+ * @method void set(string $key, TaxRuleEntity $entity)
  * @method TaxRuleEntity[] getIterator()
  * @method TaxRuleEntity[] getElements()
  * @method TaxRuleEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class TaxRuleCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return TaxRuleEntity::class;
     }

--- a/src/Data/Entity/TaxRuleType/TaxRuleTypeCollection.php
+++ b/src/Data/Entity/TaxRuleType/TaxRuleTypeCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\TaxRuleType;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(TaxRuleTypeEntity $entity)
- * @method void set(TaxRuleTypeEntity $entity)
+ * @method void set(string $key, TaxRuleTypeEntity $entity)
  * @method TaxRuleTypeEntity[] getIterator()
  * @method TaxRuleTypeEntity[] getElements()
  * @method TaxRuleTypeEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class TaxRuleTypeCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return TaxRuleTypeEntity::class;
     }

--- a/src/Data/Entity/TaxRuleTypeTranslation/TaxRuleTypeTranslationCollection.php
+++ b/src/Data/Entity/TaxRuleTypeTranslation/TaxRuleTypeTranslationCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\TaxRuleTypeTranslation;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(TaxRuleTypeTranslationEntity $entity)
- * @method void set(TaxRuleTypeTranslationEntity $entity)
+ * @method void set(string $key, TaxRuleTypeTranslationEntity $entity)
  * @method TaxRuleTypeTranslationEntity[] getIterator()
  * @method TaxRuleTypeTranslationEntity[] getElements()
  * @method TaxRuleTypeTranslationEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class TaxRuleTypeTranslationCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return TaxRuleTypeTranslationEntity::class;
     }

--- a/src/Data/Entity/Theme/ThemeCollection.php
+++ b/src/Data/Entity/Theme/ThemeCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\Theme;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(ThemeEntity $entity)
- * @method void set(ThemeEntity $entity)
+ * @method void set(string $key, ThemeEntity $entity)
  * @method ThemeEntity[] getIterator()
  * @method ThemeEntity[] getElements()
  * @method ThemeEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class ThemeCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return ThemeEntity::class;
     }

--- a/src/Data/Entity/ThemeChild/ThemeChildCollection.php
+++ b/src/Data/Entity/ThemeChild/ThemeChildCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\ThemeChild;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(ThemeChildEntity $entity)
- * @method void set(ThemeChildEntity $entity)
+ * @method void set(string $key, ThemeChildEntity $entity)
  * @method ThemeChildEntity[] getIterator()
  * @method ThemeChildEntity[] getElements()
  * @method ThemeChildEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class ThemeChildCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return ThemeChildEntity::class;
     }

--- a/src/Data/Entity/ThemeMedia/ThemeMediaCollection.php
+++ b/src/Data/Entity/ThemeMedia/ThemeMediaCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\ThemeMedia;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(ThemeMediaEntity $entity)
- * @method void set(ThemeMediaEntity $entity)
+ * @method void set(string $key, ThemeMediaEntity $entity)
  * @method ThemeMediaEntity[] getIterator()
  * @method ThemeMediaEntity[] getElements()
  * @method ThemeMediaEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class ThemeMediaCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return ThemeMediaEntity::class;
     }

--- a/src/Data/Entity/ThemeSalesChannel/ThemeSalesChannelCollection.php
+++ b/src/Data/Entity/ThemeSalesChannel/ThemeSalesChannelCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\ThemeSalesChannel;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(ThemeSalesChannelEntity $entity)
- * @method void set(ThemeSalesChannelEntity $entity)
+ * @method void set(string $key, ThemeSalesChannelEntity $entity)
  * @method ThemeSalesChannelEntity[] getIterator()
  * @method ThemeSalesChannelEntity[] getElements()
  * @method ThemeSalesChannelEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class ThemeSalesChannelCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return ThemeSalesChannelEntity::class;
     }

--- a/src/Data/Entity/ThemeTranslation/ThemeTranslationCollection.php
+++ b/src/Data/Entity/ThemeTranslation/ThemeTranslationCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\ThemeTranslation;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(ThemeTranslationEntity $entity)
- * @method void set(ThemeTranslationEntity $entity)
+ * @method void set(string $key, ThemeTranslationEntity $entity)
  * @method ThemeTranslationEntity[] getIterator()
  * @method ThemeTranslationEntity[] getElements()
  * @method ThemeTranslationEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class ThemeTranslationCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return ThemeTranslationEntity::class;
     }

--- a/src/Data/Entity/Unit/UnitCollection.php
+++ b/src/Data/Entity/Unit/UnitCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\Unit;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(UnitEntity $entity)
- * @method void set(UnitEntity $entity)
+ * @method void set(string $key, UnitEntity $entity)
  * @method UnitEntity[] getIterator()
  * @method UnitEntity[] getElements()
  * @method UnitEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class UnitCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return UnitEntity::class;
     }

--- a/src/Data/Entity/UnitTranslation/UnitTranslationCollection.php
+++ b/src/Data/Entity/UnitTranslation/UnitTranslationCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\UnitTranslation;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(UnitTranslationEntity $entity)
- * @method void set(UnitTranslationEntity $entity)
+ * @method void set(string $key, UnitTranslationEntity $entity)
  * @method UnitTranslationEntity[] getIterator()
  * @method UnitTranslationEntity[] getElements()
  * @method UnitTranslationEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class UnitTranslationCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return UnitTranslationEntity::class;
     }

--- a/src/Data/Entity/User/UserCollection.php
+++ b/src/Data/Entity/User/UserCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\User;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(UserEntity $entity)
- * @method void set(UserEntity $entity)
+ * @method void set(string $key, UserEntity $entity)
  * @method UserEntity[] getIterator()
  * @method UserEntity[] getElements()
  * @method UserEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class UserCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return UserEntity::class;
     }

--- a/src/Data/Entity/UserAccessKey/UserAccessKeyCollection.php
+++ b/src/Data/Entity/UserAccessKey/UserAccessKeyCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\UserAccessKey;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(UserAccessKeyEntity $entity)
- * @method void set(UserAccessKeyEntity $entity)
+ * @method void set(string $key, UserAccessKeyEntity $entity)
  * @method UserAccessKeyEntity[] getIterator()
  * @method UserAccessKeyEntity[] getElements()
  * @method UserAccessKeyEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class UserAccessKeyCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return UserAccessKeyEntity::class;
     }

--- a/src/Data/Entity/UserConfig/UserConfigCollection.php
+++ b/src/Data/Entity/UserConfig/UserConfigCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\UserConfig;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(UserConfigEntity $entity)
- * @method void set(UserConfigEntity $entity)
+ * @method void set(string $key, UserConfigEntity $entity)
  * @method UserConfigEntity[] getIterator()
  * @method UserConfigEntity[] getElements()
  * @method UserConfigEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class UserConfigCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return UserConfigEntity::class;
     }

--- a/src/Data/Entity/UserRecovery/UserRecoveryCollection.php
+++ b/src/Data/Entity/UserRecovery/UserRecoveryCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\UserRecovery;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(UserRecoveryEntity $entity)
- * @method void set(UserRecoveryEntity $entity)
+ * @method void set(string $key, UserRecoveryEntity $entity)
  * @method UserRecoveryEntity[] getIterator()
  * @method UserRecoveryEntity[] getElements()
  * @method UserRecoveryEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class UserRecoveryCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return UserRecoveryEntity::class;
     }

--- a/src/Data/Entity/Version/VersionCollection.php
+++ b/src/Data/Entity/Version/VersionCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\Version;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(VersionEntity $entity)
- * @method void set(VersionEntity $entity)
+ * @method void set(string $key, VersionEntity $entity)
  * @method VersionEntity[] getIterator()
  * @method VersionEntity[] getElements()
  * @method VersionEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class VersionCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return VersionEntity::class;
     }

--- a/src/Data/Entity/VersionCommit/VersionCommitCollection.php
+++ b/src/Data/Entity/VersionCommit/VersionCommitCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\VersionCommit;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(VersionCommitEntity $entity)
- * @method void set(VersionCommitEntity $entity)
+ * @method void set(string $key, VersionCommitEntity $entity)
  * @method VersionCommitEntity[] getIterator()
  * @method VersionCommitEntity[] getElements()
  * @method VersionCommitEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class VersionCommitCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return VersionCommitEntity::class;
     }

--- a/src/Data/Entity/VersionCommitData/VersionCommitDataCollection.php
+++ b/src/Data/Entity/VersionCommitData/VersionCommitDataCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\VersionCommitData;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(VersionCommitDataEntity $entity)
- * @method void set(VersionCommitDataEntity $entity)
+ * @method void set(string $key, VersionCommitDataEntity $entity)
  * @method VersionCommitDataEntity[] getIterator()
  * @method VersionCommitDataEntity[] getElements()
  * @method VersionCommitDataEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class VersionCommitDataCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return VersionCommitDataEntity::class;
     }

--- a/src/Data/Entity/Webhook/WebhookCollection.php
+++ b/src/Data/Entity/Webhook/WebhookCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\Webhook;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(WebhookEntity $entity)
- * @method void set(WebhookEntity $entity)
+ * @method void set(string $key, WebhookEntity $entity)
  * @method WebhookEntity[] getIterator()
  * @method WebhookEntity[] getElements()
  * @method WebhookEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class WebhookCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return WebhookEntity::class;
     }

--- a/src/Data/Entity/WebhookEventLog/WebhookEventLogCollection.php
+++ b/src/Data/Entity/WebhookEventLog/WebhookEventLogCollection.php
@@ -1,4 +1,7 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
 namespace Vin\ShopwareSdk\Data\Entity\WebhookEventLog;
 
 use Vin\ShopwareSdk\Data\Entity\EntityCollection;
@@ -9,7 +12,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  * This class is generated dynamically following SW entities schema
  *
  * @method void add(WebhookEventLogEntity $entity)
- * @method void set(WebhookEventLogEntity $entity)
+ * @method void set(string $key, WebhookEventLogEntity $entity)
  * @method WebhookEventLogEntity[] getIterator()
  * @method WebhookEventLogEntity[] getElements()
  * @method WebhookEventLogEntity|null get(string $key)
@@ -18,7 +21,7 @@ use Vin\ShopwareSdk\Data\Entity\EntityCollection;
  */
 class WebhookEventLogCollection extends EntityCollection
 {
-    public function getExpectedClass() : string
+    public function getExpectedClass(): string
     {
         return WebhookEventLogEntity::class;
     }


### PR DESCRIPTION
When comparing the PhpDoc block for the EntityCollection and the auto-generated sub-classes, the $key parameter is missing:

EntityCollection:
@method void set(string $key, Entity $entity)

CustomerWishlistCollection:
@method void set(CustomerWishlistEntity $entity)

This should be fixed as it e.g. leads Rector to removing the second argument for a call to set().