### PR TITLE
Update return type hint

### DIFF
--- a/src/Exception/ShopwareResponseException.php
+++ b/src/Exception/ShopwareResponseException.php
@@ -4,7 +4,7 @@ namespace Vin\ShopwareSdk\Exception;
 
 class ShopwareResponseException extends \Exception
 {
-    public function getResponse(): array
+    public function getResponse(): ?array
     {
         return json_decode($this->message, true);
     }


### PR DESCRIPTION
If json_decode fails it will return null, which then causes a TypeError because it does not match the hinted array return type.