### PR TITLE
fix: deprecated guzzle boolean headers

### DIFF
--- a/src/Repository/EntityRepository.php
+++ b/src/Repository/EntityRepository.php
@@ -286,8 +286,8 @@ class EntityRepository implements RepositoryInterface
             'sw-language-id' => $context->languageId,
             'sw-currency-id' => $context->currencyId,
             'sw-version-id' => $context->versionId,
-            'sw-inheritance' => $context->inheritance,
-            'sw-api-compatibility' => $context->compatibility,
+            'sw-inheritance' => $context->inheritance ? '1' : '0',
+            'sw-api-compatibility' => $context->compatibility ? '1' : '0',
         ], $additionalHeaders, $context->additionalHeaders);
 
         return array_filter($headers);

--- a/tests/EntityRepositoryTest.php
+++ b/tests/EntityRepositoryTest.php
@@ -76,6 +76,19 @@ class EntityRepositoryTest extends TestCase
         static::assertEquals('Gorgeous Timo Thiago Perfomancer', $product->getTranslated()['name']);
     }
 
+    public function testBuildHeadersSendsBooleanFlagsAsStrings(): void
+    {
+        $productId = '6bfa486a2c4c4e0db32c6a252baf6b3a';
+        $this->mock->append(new Response(200, [], file_get_contents(__DIR__ . '/stubs/' . $productId . '.json')));
+
+        $this->productRepository->get($productId, new Criteria(), $this->context);
+
+        $request = $this->mock->getLastRequest();
+        static::assertNotNull($request);
+        static::assertSame('1', $request->getHeaderLine('sw-inheritance'));
+        static::assertSame('1', $request->getHeaderLine('sw-api-compatibility'));
+    }
+
     public function testSearch(): void
     {
         $this->mock->append(new Response(200, [], file_get_contents(__DIR__ . '/stubs/products.json')));


### PR DESCRIPTION
In [Guzzle changelog 7.11](https://github.com/guzzle/guzzle/blob/7.11/CHANGELOG.md):
> Entry: “Deprecated non-string headers request option values, which will be rejected in 8.0”

Even though the SDK resolves to Guzzle 7.9 for development, in production some apps already resolve to Guzzle 7.11+ so the deprecation messages are already present.